### PR TITLE
Handle single sample mode

### DIFF
--- a/src/dune_tension/main.py
+++ b/src/dune_tension/main.py
@@ -98,8 +98,8 @@ def load_state():
 def create_tensiometer():
     try:
         samples = int(entry_samples.get())
-        if samples < 2:
-            raise ValueError("Samples per wire must be ≥ 2")
+        if samples < 1:
+            raise ValueError("Samples per wire must be ≥ 1")
 
         conf = float(entry_confidence.get())
         if not (0.0 <= conf <= 1.0):
@@ -209,52 +209,56 @@ tk.Checkbutton(root, text="Flipped", variable=flipped_var).grid(
     row=3, column=1, sticky="w"
 )
 
+# Measurement frame
+measurement_frame = tk.LabelFrame(root, text="Measurement")
+measurement_frame.grid(row=4, column=0, columnspan=3, pady=5, sticky="we")
+
 # Samples per wire
-tk.Label(root, text="Samples per Wire (≥2):").grid(row=4, column=0, sticky="e")
-entry_samples = tk.Entry(root)
-entry_samples.grid(row=4, column=1)
+tk.Label(measurement_frame, text="Samples per Wire (≥1):").grid(row=0, column=0, sticky="e")
+entry_samples = tk.Entry(measurement_frame)
+entry_samples.grid(row=0, column=1)
 
 # Confidence threshold
-tk.Label(root, text="Confidence Threshold (0.0–1.0):").grid(row=5, column=0, sticky="e")
-entry_confidence = tk.Entry(root)
-entry_confidence.grid(row=5, column=1)
+tk.Label(measurement_frame, text="Confidence Threshold (0.0–1.0):").grid(row=1, column=0, sticky="e")
+entry_confidence = tk.Entry(measurement_frame)
+entry_confidence.grid(row=1, column=1)
 
 # Wire number
-tk.Label(root, text="Wire Number:").grid(row=6, column=0, sticky="e")
-entry_wire = tk.Entry(root)
-entry_wire.grid(row=6, column=1)
-tk.Button(root, text="Calibrate", command=measure_calibrate).grid(row=6, column=2)
+tk.Label(measurement_frame, text="Wire Number:").grid(row=2, column=0, sticky="e")
+entry_wire = tk.Entry(measurement_frame)
+entry_wire.grid(row=2, column=1)
+tk.Button(measurement_frame, text="Calibrate", command=measure_calibrate).grid(row=2, column=2)
 
 # Wire list
-tk.Label(root, text="Wire List:").grid(row=7, column=0, sticky="e")
+tk.Label(root, text="Wire List:").grid(row=5, column=0, sticky="e")
 entry_wire_list = tk.Entry(root)
-entry_wire_list.grid(row=7, column=1)
-tk.Button(root, text="Seek Wire(s)", command=measure_list).grid(row=7, column=2)
+entry_wire_list.grid(row=5, column=1)
+tk.Button(root, text="Seek Wire(s)", command=measure_list).grid(row=5, column=2)
 
 # Measure Auto
-tk.Button(root, text="Measure Auto", command=measure_auto).grid(row=8, column=0)
+tk.Button(root, text="Measure Auto", command=measure_auto).grid(row=6, column=0)
 
 # Interrupt
-tk.Button(root, text="Interrupt", command=interrupt).grid(row=8, column=1)
+tk.Button(root, text="Interrupt", command=interrupt).grid(row=6, column=1)
 
 # Servo Speed Slider
-tk.Label(root, text="Servo Speed (1–255):").grid(row=9, column=0, sticky="e")
+tk.Label(root, text="Servo Speed (1–255):").grid(row=7, column=0, sticky="e")
 speed_slider = tk.Scale(
     root, from_=1, to=255, orient=tk.HORIZONTAL, command=servo_controller.set_speed
 )
 speed_slider.set(1)
-speed_slider.grid(row=9, column=1)
+speed_slider.grid(row=7, column=1)
 
 # Servo Acceleration Slider
-tk.Label(root, text="Servo Acceleration (1–255):").grid(row=10, column=0, sticky="e")
+tk.Label(root, text="Servo Acceleration (1–255):").grid(row=8, column=0, sticky="e")
 accel_slider = tk.Scale(
     root, from_=1, to=255, orient=tk.HORIZONTAL, command=servo_controller.set_accel
 )
 accel_slider.set(1)
-accel_slider.grid(row=10, column=1)
+accel_slider.grid(row=8, column=1)
 
 # Dwell Time Slider
-tk.Label(root, text="Dwell Time (0.00–2.00s):").grid(row=11, column=0, sticky="e")
+tk.Label(root, text="Dwell Time (0.00–2.00s):").grid(row=9, column=0, sticky="e")
 dwell_slider = tk.Scale(
     root,
     from_=0,
@@ -263,7 +267,7 @@ dwell_slider = tk.Scale(
     command=lambda val: servo_controller.set_dwell_time(float(val) / 100),
 )
 dwell_slider.set(100)
-dwell_slider.grid(row=11, column=1)
+dwell_slider.grid(row=9, column=1)
 
 load_state()
 root.mainloop()

--- a/src/dune_tension/tensiometer.py
+++ b/src/dune_tension/tensiometer.py
@@ -1,7 +1,10 @@
 import threading
-import numpy as np
+from dataclasses import dataclass
 from datetime import datetime
+from typing import Optional
 import time
+
+import numpy as np
 import pandas as pd
 from tension_calculation import (
     calculate_kde_max,
@@ -24,20 +27,39 @@ from plc_io import is_web_server_active, goto_xy
 from data_cache import get_dataframe, update_dataframe, EXPECTED_COLUMNS
 
 
+@dataclass
+class TensionResult:
+    layer: str
+    side: str
+    wire_number: int
+    tension: float = 0.0
+    tension_pass: bool = False
+    frequency: float = 0.0
+    zone: str = ""
+    confidence: float = 0.0
+    t_sigma: float = 0.0
+    x: float = 0.0
+    y: float = 0.0
+    Gcode: str = ""
+    wires: str = ""
+    ttf: float = 0.0
+    time: Optional[float] = None
+
+
 class Tensiometer:
     def __init__(
         self,
-        apa_name,
-        layer,
-        side,
-        flipped=False,
-        stop_event=None,
-        samples_per_wire=3,
-        confidence_threshold=0.7,
-        save_audio=True,
-        spoof=False,
-        spoof_movement=False,
-    ):
+        apa_name: str,
+        layer: str,
+        side: str,
+        flipped: bool = False,
+        stop_event: Optional[threading.Event] = None,
+        samples_per_wire: int = 3,
+        confidence_threshold: float = 0.7,
+        save_audio: bool = True,
+        spoof: bool = False,
+        spoof_movement: bool = False,
+    ) -> None:
         self.config = make_config(
             apa_name=apa_name,
             layer=layer,
@@ -81,7 +103,7 @@ class Tensiometer:
                 0.15, sample_rate=sample_rate, normalize=True
             )
 
-    def measure_calibrate(self, wire_number):
+    def measure_calibrate(self, wire_number: int) -> Optional[TensionResult]:
         xy = self.get_current_xy_position()
         if xy is None:
             print(
@@ -101,7 +123,7 @@ class Tensiometer:
             wire_y=y,
         )
 
-    def measure_auto(self):
+    def measure_auto(self) -> None:
         from analyze_tension_data import analyze_tension_data
 
         result = analyze_tension_data(self.config)
@@ -122,7 +144,7 @@ class Tensiometer:
             x, y = get_xy_from_file(self.config, wire_number)
             self.collect_wire_data(wire_number=wire_number, wire_x=x, wire_y=y)
 
-    def measure_list(self, wire_list, preserve_order):
+    def measure_list(self, wire_list: list[int], preserve_order: bool) -> None:
         measure_list(
             config=self.config,
             wire_list=wire_list,
@@ -137,105 +159,130 @@ class Tensiometer:
             preserve_order=preserve_order,
         )
 
-    def collect_wire_data(self, wire_number: int, wire_x, wire_y):
-        def collect_samples(start_time):
-            nonlocal wire_x, wire_y
-            wires = []
-            wiggle_start_time = time.time()
-            current_wiggle = 0.5
-            while (time.time() - start_time) < 30:
-                if self.stop_event and self.stop_event.is_set():
-                    print("tension measurement interrupted!")
-                    return None
-                audio_sample = self.record_audio_func(
-                    duration=0.15, sample_rate=self.samplerate
+    def _collect_samples(
+        self,
+        wire_number: int,
+        length: float,
+        start_time: float,
+        wire_y: float,
+    ) -> tuple[list[TensionResult] | None, float]:
+        wires: list[TensionResult] = []
+        wiggle_start_time = time.time()
+        current_wiggle = 0.5
+        while (time.time() - start_time) < 30:
+            if self.stop_event and self.stop_event.is_set():
+                print("tension measurement interrupted!")
+                return None, wire_y
+            audio_sample = self.record_audio_func(
+                duration=0.15, sample_rate=self.samplerate
+            )
+            if self.stop_event and self.stop_event.is_set():
+                print("tension measurement interrupted!")
+                return None, wire_y
+            if self.config.save_audio and not self.config.spoof:
+                np.savez(
+                    f"audio/{self.config.layer}{self.config.side}{wire_number}_{datetime.now().strftime('%Y-%m-%d_%H-%M-%S')}",
+                    audio_sample,
+                )
+            if time.time() - wiggle_start_time > 1:
+                wiggle_start_time = time.time()
+                print(f"Wiggling {current_wiggle}mm")
+                self.wiggle_func(current_wiggle)
+            if audio_sample is not None:
+                frequency, confidence, tension, tension_ok = analyze_sample(
+                    audio_sample, self.samplerate, length
                 )
                 if self.stop_event and self.stop_event.is_set():
                     print("tension measurement interrupted!")
-                    return None
-                if self.config.save_audio and not self.config.spoof:
-                    np.savez(
-                        f"audio/{self.config.layer}{self.config.side}{wire_number}_{datetime.now().strftime('%Y-%m-%d_%H-%M-%S')}",
-                        audio_sample,
-                    )
-                if time.time() - wiggle_start_time > 1:
+                    return None, wire_y
+                x, y = self.get_current_xy_position()
+                if (
+                    confidence > self.config.confidence_threshold
+                    and tension_plausible(tension)
+                ):
                     wiggle_start_time = time.time()
-                    print(f"Wiggling {current_wiggle}mm")
-                    self.wiggle_func(current_wiggle)
-                if audio_sample is not None:
-                    frequency, confidence, tension, tension_ok = analyze_sample(
-                        audio_sample, self.samplerate, length
+                    wires.append(
+                        TensionResult(
+                            layer=self.config.layer,
+                            side=self.config.side,
+                            wire_number=wire_number,
+                            tension=tension,
+                            tension_pass=tension_ok,
+                            frequency=frequency,
+                            confidence=confidence,
+                            x=x,
+                            y=y,
+                        )
                     )
-                    if self.stop_event and self.stop_event.is_set():
-                        print("tension measurement interrupted!")
-                        return None
-                    x, y = self.get_current_xy_position()
-                    if (
-                        confidence > self.config.confidence_threshold
-                        and tension_plausible(tension)
-                    ):
-                        wiggle_start_time = time.time()
-                        wires.append(
-                            {
-                                "tension": tension,
-                                "tension_pass": tension_ok,
-                                "frequency": frequency,
-                                "confidence": confidence,
-                                "x": x,
-                                "y": y,
-                            }
-                        )
-                        wire_y = np.average([d["y"] for d in wires])
-                        current_wiggle = (current_wiggle + 0.1) / 1.5
+                    wire_y = np.average([d.y for d in wires])
+                    current_wiggle = (current_wiggle + 0.1) / 1.5
+                    if self.config.samples_per_wire == 1:
+                        return wires[:1], wire_y
 
-                        cluster = has_cluster_dict(
-                            wires, "tension", self.config.samples_per_wire
-                        )
-                        if cluster != []:
-                            return cluster
-                        print(
-                            f"tension: {tension:.1f}N, frequency: {frequency:.1f}Hz, "
-                            f"confidence: {confidence * 100:.1f}%",
-                            f"y: {y:.1f}",
-                        )
-            return [] if not self.stop_event or not self.stop_event.is_set() else None
+                    cluster = has_cluster_dict(
+                        wires, "tension", self.config.samples_per_wire
+                    )
+                    if cluster != []:
+                        return cluster, wire_y
+                    print(
+                        f"tension: {tension:.1f}N, frequency: {frequency:.1f}Hz, "
+                        f"confidence: {confidence * 100:.1f}%",
+                        f"y: {y:.1f}",
+                    )
+        return ([] if not self.stop_event or not self.stop_event.is_set() else None), wire_y
 
-        def generate_result(passingWires):
-            nonlocal wire_x, wire_y
-            result = {
-                "layer": self.config.layer,
-                "side": self.config.side,
-                "wire_number": wire_number,
-                "tension": 0,
-                "tension_pass": False,
-                "frequency": 0,
-                "zone": zone_lookup(wire_x),
-                "confidence": 0,
-                "t_sigma": 0,
-                "x": wire_x,
-                "y": wire_y,
-                "Gcode": f"X{round(wire_x, 1)} Y{round(wire_y, 1)}",
-            }
+    def _generate_result(
+        self,
+        passing_wires: list[TensionResult],
+        length: float,
+        wire_number: int,
+        wire_x: float,
+        wire_y: float,
+    ) -> TensionResult:
+        result = TensionResult(
+            layer=self.config.layer,
+            side=self.config.side,
+            wire_number=wire_number,
+            zone=zone_lookup(wire_x),
+            x=wire_x,
+            y=wire_y,
+            Gcode=f"X{round(wire_x, 1)} Y{round(wire_y, 1)}",
+        )
 
-            if len(passingWires) > 0:
-                result["frequency"] = calculate_kde_max(
-                    [d["frequency"] for d in passingWires]
+        if len(passing_wires) > 0:
+            if self.config.samples_per_wire == 1:
+                first = passing_wires[0]
+                result.frequency = first.frequency
+                result.tension = first.tension
+                result.tension_pass = first.tension_pass
+                result.confidence = first.confidence
+                result.x = first.x
+                result.y = first.y
+                result.Gcode = f"X{round(result.x, 1)} Y{round(result.y, 1)}"
+                result.wires = str([float(first.tension)])
+                result.t_sigma = 0.0
+            else:
+                result.frequency = calculate_kde_max(
+                    [d.frequency for d in passing_wires]
                 )
-                result["tension"] = tension_lookup(
-                    length=length, frequency=result["frequency"]
+                result.tension = tension_lookup(
+                    length=length, frequency=result.frequency
                 )
-                result["tension_pass"] = tension_pass(result["tension"], length)
-                result["confidence"] = np.average(
-                    [d["confidence"] for d in passingWires]
+                result.tension_pass = tension_pass(result.tension, length)
+                result.confidence = np.average(
+                    [d.confidence for d in passing_wires]
                 )
-                result["t_sigma"] = np.std([d["tension"] for d in passingWires])
-                result["x"] = round(np.average([d["x"] for d in passingWires]), 1)
-                result["y"] = round(np.average([d["y"] for d in passingWires]), 1)
-                result["Gcode"] = f"X{round(result['x'], 1)} Y{round(result['y'], 1)}"
-                result["wires"] = str([float(d["tension"]) for d in passingWires])
+                result.t_sigma = np.std([d.tension for d in passing_wires])
+                result.x = round(np.average([d.x for d in passing_wires]), 1)
+                result.y = round(np.average([d.y for d in passing_wires]), 1)
+                result.Gcode = f"X{round(result.x, 1)} Y{round(result.y, 1)}"
+                result.wires = str([float(d.tension) for d in passing_wires])
 
-            return result
+        return result
 
+    def collect_wire_data(
+        self, wire_number: int, wire_x: float, wire_y: float
+    ) -> Optional[TensionResult]:
         # Main logic
         length = length_lookup(self.config.layer, wire_number, zone_lookup(wire_x))
         start_time = time.time()
@@ -244,52 +291,56 @@ class Tensiometer:
             print("Measurement interrupted.")
             return
 
-        succeed = goto_xy(wire_x, wire_y)
+        succeed = self.goto_xy_func(wire_x, wire_y)
         if self.stop_event and self.stop_event.is_set():
             print("Measurement interrupted.")
             return
         if not succeed:
-            print(f"Failed to move to wire {wire_number} position {wire_x},{wire_y}.")
-            return {
-                "layer": self.config.layer,
-                "side": self.config.side,
-                "wire_number": wire_number,
-                "tension": 0,
-                "tension_pass": False,
-                "frequency": 0,
-                "zone": zone_lookup(wire_x),
-                "confidence": 0,
-                "t_sigma": 0,
-                "x": wire_x,
-                "y": wire_y,
-                "Gcode": f"X{round(wire_x, 1)} Y{round(wire_y, 1)}",
-            }
+            print(
+                f"Failed to move to wire {wire_number} position {wire_x},{wire_y}."
+            )
+            return TensionResult(
+                layer=self.config.layer,
+                side=self.config.side,
+                wire_number=wire_number,
+                zone=zone_lookup(wire_x),
+                x=wire_x,
+                y=wire_y,
+                Gcode=f"X{round(wire_x, 1)} Y{round(wire_y, 1)}",
+            )
 
-        wires = collect_samples(start_time)
+        wires, wire_y = self._collect_samples(
+            wire_number,
+            length,
+            start_time,
+            wire_y,
+        )
         if wires is None:
             print("Measurement interrupted.")
             return
-        result = generate_result(wires)
+        result = self._generate_result(wires, length, wire_number, wire_x, wire_y)
 
-        if result["tension"] == 0:
+        if result.tension == 0:
             print(f"measurement failed for wire number {wire_number}.")
-        if not result["tension_pass"]:
+        if not result.tension_pass:
             print(f"Tension failed for wire number {wire_number}.")
         ttf = time.time() - start_time
         print(
-            f"Wire number {wire_number} has length {length * 1000:.1f}mm tension {result['tension']:.1f}N frequency {result['frequency']:.1f}Hz with confidence {result['confidence'] * 100:.1f}%.\n at {result['x']},{result['y']}\n"
+            f"Wire number {wire_number} has length {length * 1000:.1f}mm tension {result.tension:.1f}N frequency {result.frequency:.1f}Hz with confidence {result.confidence * 100:.1f}%.\n at {result.x},{result.y}\n"
             f"Took {ttf} seconds to finish."
         )
-        result["ttf"] = ttf
+        result.ttf = ttf
 
         df = get_dataframe(self.config.data_path)
-        row = {col: result.get(col, None) for col in EXPECTED_COLUMNS}
+        row = {col: getattr(result, col, None) for col in EXPECTED_COLUMNS}
         df.loc[len(df)] = row
         update_dataframe(self.config.data_path, df)
 
         return result
 
-    def load_tension_summary(self):
+    def load_tension_summary(
+        self,
+    ) -> tuple[list, list] | tuple[str, list, list]:
         try:
             df = pd.read_csv(self.config.data_path)
         except FileNotFoundError:

--- a/src/dune_tension/tension_calculation.py
+++ b/src/dune_tension/tension_calculation.py
@@ -1,6 +1,8 @@
-from scipy.stats import gaussian_kde
-import numpy as np
 from itertools import combinations
+from typing import Sequence, Any
+
+import numpy as np
+from scipy.stats import gaussian_kde
 
 WIRE_DENSITY = 0.000152
 MAX_PASSING_TENSION = 8
@@ -8,7 +10,7 @@ MIN_PHYSICAL_TENSION = 2
 MAX_PHYSICAL_TENSION = 10
 
 
-def calculate_kde_max(sample):
+def calculate_kde_max(sample: Sequence[float]) -> float:
     """
     Calculate the maximum value of the kernel density estimation (KDE) for a given sample.
 
@@ -35,37 +37,35 @@ def calculate_kde_max(sample):
     return max_kde_sample_value
 
 
-def tension_lookup(length, frequency: float):
+def tension_lookup(length: float, frequency: float) -> float:
     tension = (2 * length * frequency) ** 2 * WIRE_DENSITY
     return tension
 
 
-def tension_pass(tension, length):
+def tension_pass(tension: float, length: float) -> bool:
     return tension > min(25.8 * length + 0.232, 4) and tension < MAX_PASSING_TENSION  #
 
 
-def tension_plausible(tension):
+def tension_plausible(tension: float) -> bool:
     return tension < MAX_PHYSICAL_TENSION and tension > MIN_PHYSICAL_TENSION
 
 
-def has_cluster_dict(data, key, n):
-    """
-    Checks if any subset of size n in the list of dictionaries forms a cluster
-    based on the values of a specified key using the IQR method.
+def has_cluster_dict(
+    data: Sequence[Any], key: str, n: int
+) -> list[Any]:
+    """Return a subset of ``data`` of size ``n`` forming a cluster.
 
-    Args:
-        data (list): A list of dictionaries.
-        key (str): The key to check values for clustering.
-        n (int): The size of the subset to check.
-
-    Returns:
-        list: A subset of dictionaries that forms a cluster if one exists, otherwise an empty list.
+    ``data`` may be a list of dictionaries or objects with attributes
+    referenced by ``key``. The function checks every combination of ``n``
+    items and returns the first subset whose ``key`` values have a small
+    standard deviation (<0.1).
     """
+
     if len(data) < n:
         return []
 
     for subset in combinations(data, n):
-        values = [item[key] for item in subset]
+        values = [item[key] if isinstance(item, dict) else getattr(item, key) for item in subset]
         if np.std(values) < 0.1:
             return list(subset)
 


### PR DESCRIPTION
## Summary
- return first passing measurement if only one sample is required
- compute result directly from that sample
- allow GUI to accept samples_per_wire >=1
- add typing information for key tension functions
- place measurement controls into their own frame in the GUI

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684321f3b4348329925c1ec33ce509d3