### PR TITLE
Add dependency tests for tensiometer

### DIFF
--- a/tests/test_main_dependencies.py
+++ b/tests/test_main_dependencies.py
@@ -1,0 +1,178 @@
+import sys
+from pathlib import Path
+import types
+import time
+from threading import Thread
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src" / "dune_tension"))
+
+serial_stub = types.ModuleType("serial")
+class _Serial:
+    def __init__(self, *a, **k):
+        pass
+serial_stub.Serial = _Serial
+class _SerialException(Exception):
+    pass
+serial_stub.SerialException = _SerialException
+sys.modules["serial"] = serial_stub
+
+# Minimal tkinter stub to avoid display errors during import
+tk_stub = types.ModuleType("tkinter")
+
+class _Widget:
+    def __init__(self, *a, **k):
+        pass
+    def grid(self, *a, **k):
+        pass
+    def insert(self, *a, **k):
+        pass
+    def set(self, *a, **k):
+        pass
+    def get(self):
+        return ""
+    def after(self, *a, **k):
+        pass
+    def mainloop(self):
+        pass
+    def title(self, *a, **k):
+        pass
+
+for cls in ["Tk", "Frame", "LabelFrame", "Label", "Entry", "OptionMenu", "Checkbutton", "Button", "Scale"]:
+    setattr(tk_stub, cls, type(cls, (_Widget,), {}))
+
+class _Var:
+    def __init__(self, value=None):
+        self._value = value
+    def set(self, v):
+        self._value = v
+    def get(self):
+        return self._value
+
+tk_stub.StringVar = _Var
+tk_stub.BooleanVar = _Var
+tk_stub.HORIZONTAL = "HORIZONTAL"
+
+messagebox_stub = types.ModuleType("tkinter.messagebox")
+messagebox_stub.showerror = lambda *a, **k: None
+sys.modules["tkinter"] = tk_stub
+sys.modules["tkinter.messagebox"] = messagebox_stub
+
+# Provide a minimal tensiometer stub so main can be imported without heavy deps
+class _TensiometerStub:
+    def __init__(self, *_, **__):
+        pass
+
+tensiometer_stub = types.ModuleType("tensiometer")
+tensiometer_stub.Tensiometer = _TensiometerStub
+sys.modules["tensiometer"] = tensiometer_stub
+
+# Minimal tensiometer_functions stub with make_config
+tfunc_stub = types.ModuleType("tensiometer_functions")
+def _make_config(**kwargs):
+    cfg = types.SimpleNamespace(**kwargs)
+    cfg.data_path = f"{cfg.apa_name}_{cfg.layer}.csv"
+    return cfg
+tfunc_stub.make_config = _make_config
+sys.modules["tensiometer_functions"] = tfunc_stub
+
+import dune_tension.main as main
+from dune_tension.maestro import DummyController
+
+
+class DummyGetter:
+    def __init__(self, value):
+        self._value = value
+    def get(self):
+        return self._value
+
+
+class DummyRoot:
+    def __init__(self):
+        self.after_args = None
+    def after(self, delay, func):
+        self.after_args = (delay, func)
+
+
+class RecordController(DummyController):
+    def __init__(self):
+        super().__init__()
+        self.calls = []
+    def setTarget(self, chan, target):
+        super().setTarget(chan, target)
+        self.calls.append(target)
+
+def test_create_tensiometer_flags(monkeypatch):
+    called_args = {}
+    class DummyTensiometer:
+        def __init__(self, **kwargs):
+            called_args.update(kwargs)
+    monkeypatch.setattr(main, "Tensiometer", DummyTensiometer)
+    monkeypatch.setattr(main, "entry_apa", DummyGetter("APA"))
+    monkeypatch.setattr(main, "layer_var", DummyGetter("X"))
+    monkeypatch.setattr(main, "side_var", DummyGetter("A"))
+    monkeypatch.setattr(main, "flipped_var", DummyGetter(False))
+    monkeypatch.setattr(main, "entry_samples", DummyGetter("2"))
+    monkeypatch.setattr(main, "entry_confidence", DummyGetter("0.8"))
+    monkeypatch.setattr(main.messagebox, "showerror", lambda *a, **k: None)
+    monkeypatch.delenv("SPOOF_AUDIO", raising=False)
+    monkeypatch.delenv("SPOOF_PLC", raising=False)
+    main.create_tensiometer()
+    assert called_args["spoof"] is False
+    assert called_args["spoof_movement"] is False
+
+    called_args.clear()
+    monkeypatch.setenv("SPOOF_AUDIO", "1")
+    main.create_tensiometer()
+    assert called_args["spoof"] is True
+    assert called_args["spoof_movement"] is True
+
+    called_args.clear()
+    monkeypatch.delenv("SPOOF_AUDIO")
+    monkeypatch.setenv("SPOOF_PLC", "1")
+    main.create_tensiometer()
+    assert called_args["spoof"] is False
+    assert called_args["spoof_movement"] is True
+
+
+def test_servo_controller_run_loop():
+    servo = RecordController()
+    controller = main.ServoController(servo=servo)
+    controller.dwell_time = 0
+    controller.running.set()
+    t = Thread(target=controller.run_loop)
+    t.start()
+    time.sleep(0.05)
+    controller.running.clear()
+    t.join(timeout=1)
+    assert servo.calls[0] == 4000
+    assert servo.calls[1] == 8000
+    assert len(servo.calls) >= 2
+
+
+def test_monitor_tension_logs(monkeypatch):
+    updates = []
+    class DummyConfig:
+        apa_name = "APA"
+        layer = "X"
+        data_path = "dummy.csv"
+    monkeypatch.setattr(main, "entry_apa", DummyGetter("APA"))
+    monkeypatch.setattr(main, "layer_var", DummyGetter("X"))
+    monkeypatch.setattr(main, "side_var", DummyGetter("A"))
+    monkeypatch.setattr(main, "flipped_var", DummyGetter(False))
+    monkeypatch.setattr(main, "root", DummyRoot())
+    monkeypatch.setattr(main, "make_config", lambda **k: DummyConfig)
+    monkeypatch.setattr(main.os.path, "getmtime", lambda p: 1)
+    analyze_mod = types.ModuleType("analyze")
+    analyze_mod.update_tension_logs = lambda conf: updates.append(conf)
+    sys.modules["analyze"] = analyze_mod
+    main.monitor_tension_logs.last_path = ""
+    main.monitor_tension_logs.last_mtime = None
+    main.monitor_tension_logs()
+    assert updates and updates[-1] is DummyConfig
+    assert main.monitor_tension_logs.last_mtime == 1
+    main.monitor_tension_logs()
+    assert len(updates) == 1
+    monkeypatch.setattr(main.os.path, "getmtime", lambda p: 2)
+    main.monitor_tension_logs()
+    assert len(updates) == 2

--- a/tests/test_tensiometer.py
+++ b/tests/test_tensiometer.py
@@ -1,0 +1,206 @@
+import sys
+from pathlib import Path
+import types
+import pytest
+
+# Ensure src is on path
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+
+# ----- Stub external dependencies -----
+# Minimal numpy
+numpy_stub = types.ModuleType("numpy")
+
+
+def _avg(lst):
+    return sum(lst) / len(lst) if lst else 0.0
+
+
+def _std(lst):
+    m = _avg(lst)
+    return (sum((x - m) ** 2 for x in lst) / len(lst)) ** 0.5 if lst else 0.0
+
+
+def _linspace(a, b, n):
+    if n == 1:
+        return [a]
+    step = (b - a) / (n - 1)
+    return [a + i * step for i in range(n)]
+
+
+def _argmax(lst):
+    return max(range(len(lst)), key=lambda i: lst[i])
+
+
+numpy_stub.average = _avg
+numpy_stub.std = _std
+numpy_stub.linspace = _linspace
+numpy_stub.argmax = _argmax
+numpy_stub.isscalar = lambda x: not isinstance(x, (list, tuple))
+numpy_stub.savez = lambda *a, **k: None
+sys.modules["numpy"] = numpy_stub
+
+# Minimal pandas
+pandas_stub = types.ModuleType("pandas")
+
+
+class _Column(list):
+    def tolist(self):
+        return list(self)
+
+
+class _DataFrame:
+    def __init__(self, data):
+        self._data = {k: _Column(v) for k, v in data.items()}
+
+    def __getitem__(self, key):
+        return self._data[key]
+
+    @property
+    def columns(self):
+        return list(self._data.keys())
+
+
+def _read_csv(path):
+    p = Path(path)
+    if not p.exists():
+        raise FileNotFoundError(path)
+    lines = [line.strip() for line in p.read_text().splitlines() if line.strip()]
+    headers = lines[0].split(',')
+    cols = {h: [] for h in headers}
+    for line in lines[1:]:
+        for h, val in zip(headers, line.split(',')):
+            try:
+                cols[h].append(float(val))
+            except ValueError:
+                cols[h].append(val)
+    return _DataFrame(cols)
+
+
+pandas_stub.read_csv = _read_csv
+sys.modules["pandas"] = pandas_stub
+
+# geometry
+geo_stub = types.ModuleType("geometry")
+geo_stub.zone_lookup = lambda x: 1
+geo_stub.length_lookup = lambda layer, wire, zone: 1.0
+sys.modules["geometry"] = geo_stub
+
+# tension_calculation
+tc_stub = types.ModuleType("tension_calculation")
+tc_stub.calculate_kde_max = lambda freqs: max(freqs)
+tc_stub.tension_lookup = lambda length, frequency: frequency * 0.1
+tc_stub.tension_pass = lambda tension, length: True
+tc_stub.has_cluster_dict = lambda data, key, n: data[:n] if len(data) >= n else []
+tc_stub.tension_plausible = lambda t: True
+sys.modules["tension_calculation"] = tc_stub
+
+# audioProcessing
+ap_stub = types.ModuleType("audioProcessing")
+ap_stub.get_samplerate = lambda: None
+ap_stub.spoof_audio_sample = lambda p: []
+ap_stub.analyze_sample = lambda sample, sr, length: (sr, 1.0, 2.0, True)
+sys.modules["audioProcessing"] = ap_stub
+
+# plc_io
+plc_stub = types.ModuleType("plc_io")
+plc_stub.is_web_server_active = lambda: False
+plc_stub.spoof_get_xy = lambda: (0.0, 0.0)
+plc_stub.spoof_goto_xy = lambda x, y: True
+plc_stub.spoof_wiggle = lambda m: None
+sys.modules["plc_io"] = plc_stub
+
+# data_cache
+dc_stub = types.ModuleType("data_cache")
+dc_stub.get_dataframe = lambda path: None
+dc_stub.update_dataframe = lambda path, df: None
+dc_stub.EXPECTED_COLUMNS = []
+sys.modules["data_cache"] = dc_stub
+
+# tensiometer_functions
+tf_stub = types.ModuleType("tensiometer_functions")
+
+def _make_config(**kwargs):
+    cfg = types.SimpleNamespace(**kwargs)
+    cfg.data_path = f"{cfg.apa_name}_{cfg.layer}.csv"
+    return cfg
+
+
+tf_stub.make_config = _make_config
+tf_stub.measure_list = lambda **k: None
+tf_stub.get_xy_from_file = lambda cfg, num: (0.0, 0.0)
+tf_stub.check_stop_event = lambda evt, msg='': False
+sys.modules["tensiometer_functions"] = tf_stub
+
+from dune_tension.tensiometer import Tensiometer, TensionResult
+
+
+def test_generate_result_single_sample():
+    t = Tensiometer(apa_name="APA", layer="X", side="A", samples_per_wire=1)
+    sample = TensionResult(
+        layer="X",
+        side="A",
+        wire_number=1,
+        tension=2.0,
+        tension_pass=True,
+        frequency=5.0,
+        confidence=0.9,
+        x=1.0,
+        y=2.0,
+    )
+    result = t._generate_result([sample], length=1.0, wire_number=1, wire_x=1.5, wire_y=2.5)
+    assert result.tension == 2.0
+    assert result.frequency == 5.0
+    assert result.tension_pass
+    assert result.confidence == 0.9
+    assert result.x == 1.0
+    assert result.y == 2.0
+    assert result.zone == 1
+    assert result.wires == str([2.0])
+    assert result.t_sigma == 0.0
+
+
+def test_generate_result_multi_sample():
+    t = Tensiometer(apa_name="APA", layer="X", side="A", samples_per_wire=3)
+    wires = [
+        TensionResult(layer="X", side="A", wire_number=1, tension=2.0, frequency=1.0, confidence=0.5, x=0.0, y=0.0),
+        TensionResult(layer="X", side="A", wire_number=1, tension=2.2, frequency=2.0, confidence=0.6, x=0.2, y=0.2),
+        TensionResult(layer="X", side="A", wire_number=1, tension=1.8, frequency=3.0, confidence=0.7, x=0.4, y=0.4),
+    ]
+    result = t._generate_result(wires, length=1.0, wire_number=1, wire_x=2.0, wire_y=3.0)
+    assert result.frequency == 3.0  # max frequency via stub
+    assert result.tension == pytest.approx(0.3)  # frequency * 0.1 via stub
+    assert result.tension_pass
+    assert result.confidence == pytest.approx(_avg([0.5, 0.6, 0.7]))
+    assert result.t_sigma == pytest.approx(_std([2.0, 2.2, 1.8]))
+    assert result.x == pytest.approx(_avg([0.0, 0.2, 0.4]), rel=1e-7)
+    assert result.y == pytest.approx(_avg([0.0, 0.2, 0.4]), rel=1e-7)
+    assert result.wires == str([2.0, 2.2, 1.8])
+
+
+def test_load_tension_summary(tmp_path):
+    csv = tmp_path / "test.csv"
+    csv.write_text("A,B\n1,2\n3,4\n")
+    t = Tensiometer(apa_name="APA", layer="X", side="A")
+    t.config.data_path = str(csv)
+    a, b = t.load_tension_summary()
+    assert a == [1.0, 3.0]
+    assert b == [2.0, 4.0]
+
+
+def test_load_tension_summary_missing(tmp_path):
+    csv = tmp_path / "missing.csv"
+    t = Tensiometer(apa_name="APA", layer="X", side="A")
+    t.config.data_path = str(csv)
+    msg, a, b = t.load_tension_summary()
+    assert "File not found" in msg
+    assert a == [] and b == []
+
+
+def test_load_tension_summary_bad_columns(tmp_path):
+    csv = tmp_path / "bad.csv"
+    csv.write_text("C,D\n1,2\n")
+    t = Tensiometer(apa_name="APA", layer="X", side="A")
+    t.config.data_path = str(csv)
+    msg, a, b = t.load_tension_summary()
+    assert "missing" in msg
+    assert a == [] and b == []


### PR DESCRIPTION
## Summary
- add unit tests covering Tensiometer internals
- stub pandas, numpy and other heavy modules so tests can import `tensiometer`
- verify `_generate_result` and `load_tension_summary`
- confirm handling of missing files and invalid columns

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6844572e44388329b13ee2e8357f01c8