### PR TITLE
Add manual move controls to GUI

### DIFF
--- a/src/dune_tension/main.py
+++ b/src/dune_tension/main.py
@@ -8,6 +8,26 @@ from threading import Event, Thread
 import time
 from maestro import Controller, DummyController
 
+try:
+    from plc_io import (
+        get_xy as _get_xy,
+        goto_xy as _goto_xy,
+        spoof_get_xy,
+        spoof_goto_xy,
+    )
+except Exception:  # pragma: no cover - fallback for missing deps
+    def _get_xy():
+        return (0.0, 0.0)
+
+    def _goto_xy(x, y):
+        return True
+
+    def spoof_get_xy():
+        return (0.0, 0.0)
+
+    def spoof_goto_xy(x, y):
+        return True
+
 state_file = "gui_state.json"
 stop_event = Event()
 
@@ -51,6 +71,14 @@ if os.environ.get("SPOOF_SERVO") or os.environ.get("SPOOF_AUDIO"):
     servo_controller = ServoController(servo=DummyController())
 else:
     servo_controller = ServoController()
+
+# Determine which PLC functions to use for manual movement
+if os.environ.get("SPOOF_PLC") or os.environ.get("SPOOF_AUDIO"):
+    _get_xy_func = spoof_get_xy
+    _goto_xy_func = spoof_goto_xy
+else:
+    _get_xy_func = _get_xy
+    _goto_xy_func = _goto_xy
 
 
 def save_state():
@@ -222,6 +250,34 @@ monitor_tension_logs.last_path = ""
 monitor_tension_logs.last_mtime = None
 
 
+def manual_goto():
+    """Move the winder to the X,Y position entered in :data:`entry_xy`."""
+    text = entry_xy.get()
+    try:
+        x_str, y_str = text.split(",")
+        x_val = float(x_str.strip())
+        y_val = float(y_str.strip())
+    except ValueError:
+        print(f"Invalid coordinates: {text}")
+        return
+    _goto_xy_func(x_val, y_val)
+
+
+def manual_increment(dx: float, dy: float):
+    """Move the winder by 0.1 mm increments in the specified direction."""
+    cur_x, cur_y = _get_xy_func()
+
+    # Determine x-axis orientation based on side/flipped state
+    if (side_var.get() == "A" and not flipped_var.get()) or (
+        side_var.get() == "B" and flipped_var.get()
+    ):
+        x_sign = 1.0
+    else:
+        x_sign = -1.0
+
+    _goto_xy_func(cur_x + x_sign * dx * 0.1, cur_y + dy * 0.1)
+
+
 root = tk.Tk()
 root.title("Tensiometer GUI")
 
@@ -332,6 +388,36 @@ dwell_slider = tk.Scale(
 )
 dwell_slider.set(100)
 dwell_slider.grid(row=2, column=1)
+
+# --- Manual Move -----------------------------------------------------------
+manual_move_frame = tk.LabelFrame(bottom_frame, text="Manual Move")
+manual_move_frame.grid(row=3, column=0, sticky="ew", pady=5)
+
+tk.Label(manual_move_frame, text="X,Y:").grid(row=0, column=0, sticky="e")
+entry_xy = tk.Entry(manual_move_frame)
+entry_xy.grid(row=0, column=1)
+tk.Button(manual_move_frame, text="Go", command=manual_goto).grid(row=0, column=2)
+
+pad_frame = tk.Frame(manual_move_frame)
+pad_frame.grid(row=1, column=0, columnspan=3)
+
+btn_specs = [
+    ("\u2196", -1, 1, 0, 0),
+    ("\u2191", 0, 1, 0, 1),
+    ("\u2197", 1, 1, 0, 2),
+    ("\u2190", -1, 0, 1, 0),
+    ("\u2192", 1, 0, 1, 2),
+    ("\u2199", -1, -1, 2, 0),
+    ("\u2193", 0, -1, 2, 1),
+    ("\u2198", 1, -1, 2, 2),
+]
+for label, dx, dy, r, c in btn_specs:
+    tk.Button(
+        pad_frame,
+        text=label,
+        command=lambda dx=dx, dy=dy: manual_increment(dx, dy),
+        width=2,
+    ).grid(row=r, column=c)
 
 
 load_state()

--- a/tests/test_main_dependencies.py
+++ b/tests/test_main_dependencies.py
@@ -176,3 +176,31 @@ def test_monitor_tension_logs(monkeypatch):
     monkeypatch.setattr(main.os.path, "getmtime", lambda p: 2)
     main.monitor_tension_logs()
     assert len(updates) == 2
+
+
+def test_manual_increment_orientation(monkeypatch):
+    moves = []
+    monkeypatch.setattr(main, "_get_xy_func", lambda: (0.0, 0.0))
+    monkeypatch.setattr(main, "_goto_xy_func", lambda x, y: moves.append((x, y)))
+
+    def do_test(side, flipped, expected):
+        moves.clear()
+        monkeypatch.setattr(main, "side_var", DummyGetter(side))
+        monkeypatch.setattr(main, "flipped_var", DummyGetter(flipped))
+        main.manual_increment(1, 0)
+        assert moves[-1] == (expected, 0.0)
+
+    # right is +x for A not flipped and B flipped
+    do_test("A", False, 0.1)
+    do_test("B", True, 0.1)
+
+    # otherwise reversed
+    do_test("A", True, -0.1)
+    do_test("B", False, -0.1)
+
+    # verify Y increments unaffected
+    moves.clear()
+    monkeypatch.setattr(main, "side_var", DummyGetter("A"))
+    monkeypatch.setattr(main, "flipped_var", DummyGetter(False))
+    main.manual_increment(0, 1)
+    assert moves[-1] == (0.0, 0.1)


### PR DESCRIPTION
## Summary
- allow manual positioning of the winder
- add directional movement buttons and XY entry field
- respect side/flipped orientation for manual move buttons

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68445d811ea08329bea7ff0ec28ea9dd