### PR TITLE
Add wire length tracking

### DIFF
--- a/src/dune_tension/data_cache.py
+++ b/src/dune_tension/data_cache.py
@@ -9,6 +9,7 @@ EXPECTED_COLUMNS = [
     "layer",
     "side",
     "wire_number",
+    "wire_length",
     "tension",
     "tension_pass",
     "frequency",

--- a/src/dune_tension/tensiometer.py
+++ b/src/dune_tension/tensiometer.py
@@ -34,6 +34,7 @@ class TensionResult:
     layer: str
     side: str
     wire_number: int
+    wire_length: float = 0.0
     tension: float = 0.0
     tension_pass: bool = False
     frequency: float = 0.0
@@ -208,6 +209,7 @@ class Tensiometer:
                             layer=self.config.layer,
                             side=self.config.side,
                             wire_number=wire_number,
+                            wire_length=length,
                             tension=tension,
                             tension_pass=tension_ok,
                             frequency=frequency,
@@ -247,6 +249,7 @@ class Tensiometer:
             layer=self.config.layer,
             side=self.config.side,
             wire_number=wire_number,
+            wire_length=length,
             zone=zone_lookup(wire_x),
             x=wire_x,
             y=wire_y,
@@ -301,6 +304,7 @@ class Tensiometer:
                 layer=self.config.layer,
                 side=self.config.side,
                 wire_number=wire_number,
+                wire_length=length,
                 zone=zone_lookup(wire_x),
                 x=wire_x,
                 y=wire_y,

--- a/tests/test_tensiometer.py
+++ b/tests/test_tensiometer.py
@@ -157,6 +157,7 @@ def test_generate_result_single_sample():
     assert result.zone == 1
     assert result.wires == str([2.0])
     assert result.t_sigma == 0.0
+    assert result.wire_length == 1.0
 
 
 def test_generate_result_multi_sample():
@@ -175,6 +176,7 @@ def test_generate_result_multi_sample():
     assert result.x == pytest.approx(_avg([0.0, 0.2, 0.4]), rel=1e-7)
     assert result.y == pytest.approx(_avg([0.0, 0.2, 0.4]), rel=1e-7)
     assert result.wires == str([2.0, 2.2, 1.8])
+    assert result.wire_length == 1.0
 
 
 def test_load_tension_summary(tmp_path):


### PR DESCRIPTION
## Summary
- add `wire_length` attribute to `TensionResult`
- log `wire_length` in CSV data
- set wire length in measurement results
- test that `_generate_result` returns wire length

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68446cfa9c488329997ee46d4f1301fe