### PR TITLE
Fix spoof audio freq & handle GUI cleanup

### DIFF
--- a/src/dune_tension/audioProcessing.py
+++ b/src/dune_tension/audioProcessing.py
@@ -288,7 +288,7 @@ def spoof_audio_sample(npz_dir: str) -> np.ndarray:
     if data is None:
         # Generate a one second 80 Hz square wave at 41 kHz
         sample_rate = 41000
-        freq = 60
+        freq = 80
         total_samples = sample_rate
         wave = []
         for i in range(total_samples):

--- a/src/dune_tension/main.py
+++ b/src/dune_tension/main.py
@@ -246,6 +246,18 @@ def manual_increment(dx: float, dy: float):
 root = tk.Tk()
 root.title("Tensiometer GUI")
 
+
+def _on_close() -> None:
+    """Gracefully shut down threads and destroy the root window."""
+    stop_event.set()
+    servo_controller.stop_loop()
+    try:
+        root.destroy()
+    except Exception:
+        pass
+
+root.protocol("WM_DELETE_WINDOW", _on_close)
+
 # --- Layout Frames ---------------------------------------------------------
 # The GUI is split into logical areas to make it easier to navigate.  "apa_frame"
 # holds general information about the APA being measured.  "measure_frame"

--- a/tests/test_main_dependencies.py
+++ b/tests/test_main_dependencies.py
@@ -37,6 +37,10 @@ class _Widget:
         pass
     def title(self, *a, **k):
         pass
+    def protocol(self, *a, **k):
+        pass
+    def destroy(self, *a, **k):
+        pass
 
 for cls in ["Tk", "Frame", "LabelFrame", "Label", "Entry", "OptionMenu", "Checkbutton", "Button", "Scale"]:
     setattr(tk_stub, cls, type(cls, (_Widget,), {}))


### PR DESCRIPTION
## Summary
- ensure `spoof_audio_sample` fallback uses 80 Hz
- clean up GUI threads on window close
- update tkinter stubs in tests for new protocol method

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684483f2b45c832986d6674b9e6e15eb