### PR TITLE
Fix side column type in analysis

### DIFF
--- a/src/dune_tension/analyze.py
+++ b/src/dune_tension/analyze.py
@@ -118,6 +118,7 @@ def preprocess_dataframe(df: pd.DataFrame) -> pd.DataFrame:
     df["wire_number"] = pd.to_numeric(df["wire_number"], errors="coerce")
     df["tension"] = pd.to_numeric(df["tension"], errors="coerce")
     df["tension_pass"] = df["tension_pass"].astype(str) == "True"
+    df["side"] = df["side"].astype(str)
     df = df.dropna(subset=["wire_number", "tension"])
     df = df[df["tension"] > 0]
     return df
@@ -139,6 +140,7 @@ def analyze_by_side(
     grouped_by_side = latest_df.groupby("side")
 
     for side, group in grouped_by_side:
+        side = str(side)
         group_sorted = group.sort_values(by="wire_number")
         wire_numbers = group_sorted["wire_number"].astype(int).values
         if len(wire_numbers) == 0:


### PR DESCRIPTION
## Summary
- ensure `side` column is treated as a string in `preprocess_dataframe`
- explicitly cast group labels to string when analyzing by side

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6844a65207848329a25c199f182e5438