### PR TITLE
Fix Tkinter crash with background pitch detection

### DIFF
--- a/src/dune_tension/audioProcessing.py
+++ b/src/dune_tension/audioProcessing.py
@@ -1,5 +1,14 @@
 # audioProcessing.py
 import numpy as np
+
+# Avoid using Tk based backends which can conflict with the Tkinter GUI when
+# pitch detection runs in a background thread.
+# Force matplotlib to use a non-interactive backend.  This avoids initialization
+# of Tk when running in the GUI and keeps unit tests that stub out the
+# ``matplotlib`` module from failing.  ``MPLBACKEND`` is respected by matplotlib
+# if set before importing ``pyplot``.
+import os
+os.environ.setdefault("MPLBACKEND", "Agg")
 import matplotlib.pyplot as plt
 import crepe
 from tension_calculation import (


### PR DESCRIPTION
## Summary
- ensure matplotlib uses a non-interactive backend

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6844d0ae945c8329a7cf21a138bdf964