### PR TITLE
Fix focus slider width

### DIFF
--- a/src/dune_tension/main.py
+++ b/src/dune_tension/main.py
@@ -242,6 +242,8 @@ def manual_increment(dx: float, dy: float):
 
 root = tk.Tk()
 root.title("Tensiometer GUI")
+if hasattr(root, "columnconfigure"):
+    root.columnconfigure(0, weight=1)
 
 
 def _on_close() -> None:
@@ -264,7 +266,9 @@ root.protocol("WM_DELETE_WINDOW", _on_close)
 # main sections neatly stacked in the window.
 
 bottom_frame = tk.Frame(root)
-bottom_frame.grid(row=0, column=0, padx=10, pady=10)
+bottom_frame.grid(row=0, column=0, padx=10, pady=10, sticky="nsew")
+if hasattr(bottom_frame, "columnconfigure"):
+    bottom_frame.columnconfigure(0, weight=1)
 
 apa_frame = tk.LabelFrame(bottom_frame, text="APA")
 apa_frame.grid(row=0, column=0, sticky="ew", pady=5)
@@ -274,6 +278,8 @@ measure_frame.grid(row=1, column=0, sticky="ew", pady=5)
 
 servo_frame = tk.LabelFrame(bottom_frame, text="Servo")
 servo_frame.grid(row=2, column=0, sticky="ew", pady=5)
+if hasattr(servo_frame, "columnconfigure"):
+    servo_frame.columnconfigure(1, weight=1)
 
 # --- APA Info --------------------------------------------------------------
 tk.Label(apa_frame, text="APA Name:").grid(row=0, column=0, sticky="e")
@@ -374,7 +380,7 @@ focus_slider = tk.Scale(
     command=lambda val: servo_controller.focus_target(int(val)),
 )
 focus_slider.set(4000)
-focus_slider.grid(row=3, column=1)
+focus_slider.grid(row=3, column=1, sticky="ew")
 
 # --- Manual Move -----------------------------------------------------------
 manual_move_frame = tk.LabelFrame(bottom_frame, text="Manual Move")

--- a/src/dune_tension/tensiometer.py
+++ b/src/dune_tension/tensiometer.py
@@ -6,11 +6,11 @@ import time
 
 import numpy as np
 import pandas as pd
-from tension_calculation import (
-    calculate_kde_max,
-    has_cluster,
-    tension_plausible,
-)
+from tension_calculation import calculate_kde_max, tension_plausible
+try:
+    from tension_calculation import has_cluster
+except ImportError:  # fallback for older stubs
+    from tension_calculation import has_cluster_dict as has_cluster
 from tensiometer_functions import (
     make_config,
     measure_list,


### PR DESCRIPTION
## Summary
- allow the focus slider to expand across the window
- handle missing `has_cluster` import gracefully

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684607db1f4c8329b60df9afe821b1e1