### PR TITLE
Fix monitor_tension_logs parameter usage

### DIFF
--- a/src/dune_tension/main.py
+++ b/src/dune_tension/main.py
@@ -178,11 +178,27 @@ def interrupt():
 
 def monitor_tension_logs():
     """Check for updates to the tension data file and refresh logs."""
+    try:
+        samples = int(entry_samples.get())
+        if samples < 1:
+            raise ValueError
+    except Exception:
+        samples = 3
+
+    try:
+        conf = float(entry_confidence.get())
+        if not (0.0 <= conf <= 1.0):
+            raise ValueError
+    except Exception:
+        conf = 0.7
+
     config = make_config(
         apa_name=entry_apa.get(),
         layer=layer_var.get(),
         side=side_var.get(),
         flipped=flipped_var.get(),
+        samples_per_wire=samples,
+        confidence_threshold=conf,
     )
 
     path = config.data_path

--- a/tests/test_main_dependencies.py
+++ b/tests/test_main_dependencies.py
@@ -201,6 +201,7 @@ def test_servo_controller_run_loop():
 
 def test_monitor_tension_logs(monkeypatch):
     updates = []
+    called_args = {}
 
     class DummyConfig:
         apa_name = "APA"
@@ -212,15 +213,24 @@ def test_monitor_tension_logs(monkeypatch):
     monkeypatch.setattr(main, "side_var", DummyGetter("A"))
     monkeypatch.setattr(main, "flipped_var", DummyGetter(False))
     monkeypatch.setattr(main, "root", DummyRoot())
-    monkeypatch.setattr(main, "make_config", lambda **k: DummyConfig)
+    def dummy_make_config(**kwargs):
+        called_args.update(kwargs)
+        return DummyConfig
+
+    monkeypatch.setattr(main, "make_config", dummy_make_config)
     monkeypatch.setattr(main.os.path, "getmtime", lambda p: 1)
     analyze_mod = types.ModuleType("analyze")
     analyze_mod.update_tension_logs = lambda conf: updates.append(conf)
     sys.modules["analyze"] = analyze_mod
+    monkeypatch.setattr(main, "entry_samples", DummyGetter("5"))
+    monkeypatch.setattr(main, "entry_confidence", DummyGetter("0.9"))
+
     main.monitor_tension_logs.last_path = ""
     main.monitor_tension_logs.last_mtime = None
     main.monitor_tension_logs()
     assert updates and updates[-1] is DummyConfig
+    assert called_args["samples_per_wire"] == 5
+    assert called_args["confidence_threshold"] == 0.9
     assert main.monitor_tension_logs.last_mtime == 1
     main.monitor_tension_logs()
     assert len(updates) == 1


### PR DESCRIPTION
## Summary
- align `monitor_tension_logs` config parameters with the active GUI values
- test new arguments are forwarded correctly in `monitor_tension_logs`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684853b13a008329978fc7e0a91dbc8b