### PR TITLE
Separate spoofing flags

### DIFF
--- a/src/dune_tension/main.py
+++ b/src/dune_tension/main.py
@@ -33,13 +33,13 @@ state_file = "gui_state.json"
 stop_event = Event()
 
 
-if os.environ.get("SPOOF_SERVO") or os.environ.get("SPOOF_AUDIO"):
+if os.environ.get("SPOOF_SERVO"):
     servo_controller = ServoController(servo=DummyController())
 else:
     servo_controller = ServoController()
 
 # Determine which PLC functions to use for manual movement
-if os.environ.get("SPOOF_PLC") or os.environ.get("SPOOF_AUDIO"):
+if os.environ.get("SPOOF_PLC"):
     _get_xy_func = spoof_get_xy
     _goto_xy_func = spoof_goto_xy
 else:
@@ -113,7 +113,7 @@ def create_tensiometer():
         side=side_var.get(),
         flipped=flipped_var.get(),
         spoof=spoof_audio,
-        spoof_movement=bool(os.environ.get("SPOOF_PLC") or spoof_audio),
+        spoof_movement=bool(os.environ.get("SPOOF_PLC")),
         stop_event=stop_event,
         samples_per_wire=samples,
         confidence_threshold=conf,

--- a/tests/test_main_dependencies.py
+++ b/tests/test_main_dependencies.py
@@ -167,6 +167,7 @@ def test_create_tensiometer_flags(monkeypatch):
     monkeypatch.setattr(main.messagebox, "showerror", lambda *a, **k: None)
     monkeypatch.delenv("SPOOF_AUDIO", raising=False)
     monkeypatch.delenv("SPOOF_PLC", raising=False)
+    monkeypatch.delenv("SPOOF_SERVO", raising=False)
     main.create_tensiometer()
     assert called_args["spoof"] is False
     assert called_args["spoof_movement"] is False
@@ -176,12 +177,13 @@ def test_create_tensiometer_flags(monkeypatch):
     monkeypatch.setenv("SPOOF_AUDIO", "1")
     main.create_tensiometer()
     assert called_args["spoof"] is True
-    assert called_args["spoof_movement"] is True
+    assert called_args["spoof_movement"] is False
     assert called_args["plot_audio"] is True
 
     called_args.clear()
     monkeypatch.delenv("SPOOF_AUDIO")
     monkeypatch.setenv("SPOOF_PLC", "1")
+    monkeypatch.delenv("SPOOF_SERVO", raising=False)
     main.create_tensiometer()
     assert called_args["spoof"] is False
     assert called_args["spoof_movement"] is True


### PR DESCRIPTION
## Summary
- treat SPOOF_AUDIO, SPOOF_PLC and SPOOF_SERVO independently
- update `create_tensiometer()` flags
- adjust tests for new behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684871fa08188329a0bcef50725c7d25