### PR TITLE
Add threaded wiggle

### DIFF
--- a/src/dune_tension/plc_io.py
+++ b/src/dune_tension/plc_io.py
@@ -1,4 +1,5 @@
 import requests
+import threading
 import time
 from random import gauss
 
@@ -170,8 +171,13 @@ def increment(increment_x, increment_y):
 
 
 def wiggle(step):
-    """Wiggle the winder by a given step size."""
-    increment(0, gauss(0, step))
+    """Wiggle the winder by a given step size in a background thread."""
+
+    def _do_wiggle() -> None:
+        increment(0, gauss(0, step))
+
+    threading.Thread(target=_do_wiggle, daemon=True).start()
+    return True
 
 
 def is_web_server_active():


### PR DESCRIPTION
## Summary
- run `wiggle` movements in a background thread so audio recording loop isn't blocked

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684c80d43c5883299655e40869c16109