### PR TITLE
Move servo loop control to tensiometer

### DIFF
--- a/src/dune_tension/main.py
+++ b/src/dune_tension/main.py
@@ -121,13 +121,14 @@ def create_tensiometer():
         samples_per_wire=samples,
         confidence_threshold=conf,
         plot_audio=plot_audio_var.get(),
+        start_servo_loop=servo_controller.start_loop,
+        stop_servo_loop=servo_controller.stop_loop,
     )
 
 
 def measure_calibrate():
     def run():
         stop_event.clear()
-        servo_controller.start_loop()
         t = None
         try:
             t = create_tensiometer()
@@ -141,7 +142,6 @@ def measure_calibrate():
                     t.close()
                 except Exception:
                     pass
-            servo_controller.stop_loop()
             stop_event.clear()
 
     Thread(target=run, daemon=True).start()
@@ -150,7 +150,6 @@ def measure_calibrate():
 def measure_auto():
     def run():
         stop_event.clear()
-        servo_controller.start_loop()
         t = None
         try:
             t = create_tensiometer()
@@ -162,7 +161,6 @@ def measure_auto():
                     t.close()
                 except Exception:
                     pass
-            servo_controller.stop_loop()
             stop_event.clear()
 
     Thread(target=run, daemon=True).start()
@@ -171,7 +169,6 @@ def measure_auto():
 def measure_list():
     def run():
         stop_event.clear()
-        servo_controller.start_loop()
         t = None
         try:
             t = create_tensiometer()
@@ -189,7 +186,6 @@ def measure_list():
                     t.close()
                 except Exception:
                     pass
-            servo_controller.stop_loop()
             stop_event.clear()
 
     Thread(target=run, daemon=True).start()

--- a/src/dune_tension/tensiometer.py
+++ b/src/dune_tension/tensiometer.py
@@ -1,6 +1,6 @@
 import threading
 from datetime import datetime
-from typing import Optional
+from typing import Optional, Callable
 import time
 import numpy as np
 import pandas as pd
@@ -46,6 +46,8 @@ class Tensiometer:
         plot_audio: bool = False,
         spoof: bool = False,
         spoof_movement: bool = False,
+        start_servo_loop: Optional[Callable[[], None]] = None,
+        stop_servo_loop: Optional[Callable[[], None]] = None,
     ) -> None:
         self.config = make_config(
             apa_name=apa_name,
@@ -79,6 +81,9 @@ class Tensiometer:
         self.get_current_xy_position = get_xy
         self.goto_xy_func = goto_xy
         self.wiggle_func = wiggle
+
+        self.start_servo_loop = start_servo_loop or (lambda: None)
+        self.stop_servo_loop = stop_servo_loop or (lambda: None)
 
         self.samplerate = get_samplerate()
         if self.samplerate is None or spoof:
@@ -395,12 +400,16 @@ class Tensiometer:
                 time=datetime.now(),
             )
 
-        wires, wire_y = self._collect_samples(
-            wire_number=wire_number,
-            length=length,
-            start_time=start_time,
-            wire_y=wire_y,
-        )
+        self.start_servo_loop()
+        try:
+            wires, wire_y = self._collect_samples(
+                wire_number=wire_number,
+                length=length,
+                start_time=start_time,
+                wire_y=wire_y,
+            )
+        finally:
+            self.stop_servo_loop()
 
         if wires is None:
             return


### PR DESCRIPTION
## Summary
- start and stop the servo controller loop from `Tensiometer.collect_wire_data`
- pass servo loop callbacks when creating a `Tensiometer`
- remove loop control from GUI measurement functions

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685074e555488329850c48cbcda262d4