### PR TITLE
Add focus servo jiggle separate from PLC

### DIFF
--- a/src/dune_tension/main.py
+++ b/src/dune_tension/main.py
@@ -123,6 +123,7 @@ def create_tensiometer():
         plot_audio=plot_audio_var.get(),
         start_servo_loop=servo_controller.start_loop,
         stop_servo_loop=servo_controller.stop_loop,
+        focus_wiggle=servo_controller.wiggle_focus,
     )
 
 
@@ -194,13 +195,13 @@ def measure_list():
 def _parse_ranges(text: str) -> list[tuple[int, int]]:
     """Return list of ``(start, end)`` tuples parsed from ``text``."""
     ranges: list[tuple[int, int]] = []
-    for part in text.split(','):
+    for part in text.split(","):
         part = part.strip()
         if not part:
             continue
-        if '-' in part:
+        if "-" in part:
             try:
-                a, b = part.split('-', 1)
+                a, b = part.split("-", 1)
                 start = int(a)
                 end = int(b)
             except ValueError:
@@ -373,9 +374,7 @@ def update_focus_command_indicator(val: int) -> None:
         else:
             x = (val - low) / (high - low) * length
         r = 3
-        focus_command_canvas.coords(
-            focus_command_dot, x - r, 5 - r, x + r, 5 + r
-        )
+        focus_command_canvas.coords(focus_command_dot, x - r, 5 - r, x + r, 5 + r)
 
     root.after(0, _update)
 
@@ -543,7 +542,9 @@ if hasattr(tk, "Canvas"):
     focus_command_canvas = tk.Canvas(servo_frame, height=10)
     focus_command_canvas.grid(row=4, column=1, sticky="ew")
     focus_command_canvas.create_line(0, 5, int(focus_slider.cget("length")), 5)
-    focus_command_dot = focus_command_canvas.create_oval(0, 0, 0, 0, fill="blue", outline="")
+    focus_command_dot = focus_command_canvas.create_oval(
+        0, 0, 0, 0, fill="blue", outline=""
+    )
     update_focus_command_indicator(focus_slider.get())
 
 # --- Manual Move -----------------------------------------------------------
@@ -578,5 +579,14 @@ for label, dx, dy, r, c in btn_specs:
 
 
 load_state()
+try:
+    val = int(focus_slider.get())
+except Exception:
+    val = 4000
+servo_controller.focus_position = val
+try:
+    servo_controller.focus_target(val)
+except Exception:
+    pass
 root.after(1000, monitor_tension_logs)
 root.mainloop()

--- a/src/dune_tension/plc_io.py
+++ b/src/dune_tension/plc_io.py
@@ -189,30 +189,7 @@ def wiggle(step):
     def _do_wiggle() -> None:
         y_wiggle = gauss(0, step)
         increment(0, y_wiggle)
-        # Also jiggle the focus servo if available. Import lazily to avoid
-        # circular dependencies when :mod:`plc_io` is used without the GUI.
-        focus_wiggle = 0
-        try:
-            from dune_tension import main  # type: ignore
-
-            slider = getattr(main, "focus_slider", None)
-            controller = getattr(main, "servo_controller", None)
-            if slider is not None and controller is not None:
-                focus_wiggle = gauss(0, 10)
-                new_val = slider.get() 
-                # Constrain to the slider's range before sending the command
-                low = int(slider["from"])
-                high = int(slider["to"])
-                new_val = max(low, min(high, int(new_val)))
-                slider.set(new_val)
-                try:
-                    controller.focus_target(int(new_val))
-                except Exception:
-                    pass
-        except Exception:
-            # If anything goes wrong (e.g. GUI not loaded), just ignore
-            pass
-        print(f"Wiggling by {y_wiggle} mm, focus wiggle: {focus_wiggle}")
+        print(f"Wiggling by {y_wiggle} mm")
 
     threading.Thread(target=_do_wiggle, daemon=True).start()
     return True


### PR DESCRIPTION
## Summary
- stop moving the focus servo in `plc_io.wiggle`
- track the focus servo position in `ServoController`
- add `wiggle_focus` helper and use it during data collection
- set focus position from the GUI slider on startup

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68507bbbd77483299b491b20173c0724