### PR TITLE
Add GUI button to remeasure failing wires

### DIFF
--- a/src/dune_tension/main.py
+++ b/src/dune_tension/main.py
@@ -167,6 +167,25 @@ def measure_auto():
     Thread(target=run, daemon=True).start()
 
 
+def measure_failing():
+    def run():
+        stop_event.clear()
+        t = None
+        try:
+            t = create_tensiometer()
+            save_state()
+            t.measure_failing()
+        finally:
+            if t is not None:
+                try:
+                    t.close()
+                except Exception:
+                    pass
+            stop_event.clear()
+
+    Thread(target=run, daemon=True).start()
+
+
 def measure_list():
     def run():
         stop_event.clear()
@@ -481,6 +500,10 @@ tk.Label(measure_frame, text="Clear Range:").grid(row=5, column=0, sticky="e")
 entry_clear_range = tk.Entry(measure_frame)
 entry_clear_range.grid(row=5, column=1)
 tk.Button(measure_frame, text="Clear", command=clear_range).grid(row=5, column=2)
+
+tk.Button(measure_frame, text="Remeasure Failing", command=measure_failing).grid(
+    row=6, column=0, pady=(5, 0)
+)
 
 # --- Servo Parameters ------------------------------------------------------
 tk.Label(servo_frame, text="Servo Speed (1–255):").grid(row=0, column=0, sticky="e")

--- a/src/dune_tension/tensiometer.py
+++ b/src/dune_tension/tensiometer.py
@@ -195,6 +195,32 @@ class Tensiometer:
                 self.collect_wire_data(wire_number=wire_number, wire_x=x, wire_y=y)
         print("Done measuring all wires")
 
+    def measure_failing(self) -> None:
+        from analyze import get_failed_wires
+
+        wires_dict = get_failed_wires(self.config)
+        wires_to_measure = wires_dict.get(self.config.side, [])
+
+        print(f"Failing wires: {wires_to_measure}")
+
+        if not wires_to_measure:
+            print("No failing wires found.")
+            return
+
+        for wire_number in wires_to_measure:
+            if check_stop_event(self.stop_event):
+                return
+
+            xy = get_xy_from_file(self.config, wire_number)
+            if xy is None:
+                print(f"No position data found for wire {wire_number}")
+            else:
+                x, y = xy
+                self.goto_xy_func(x, y)
+                print(f"Remeasuring wire {wire_number} at position {x},{y}")
+                self.collect_wire_data(wire_number=wire_number, wire_x=x, wire_y=y)
+        print("Done remeasuring failing wires")
+
     def measure_list(self, wire_list: list[int], preserve_order: bool) -> None:
         measure_list(
             config=self.config,

--- a/tests/test_tensiometer.py
+++ b/tests/test_tensiometer.py
@@ -83,6 +83,7 @@ sys.modules["pandas"] = pandas_stub
 geo_stub = types.ModuleType("geometry")
 geo_stub.zone_lookup = lambda x: 1
 geo_stub.length_lookup = lambda layer, wire, zone: 1.0
+geo_stub.refine_position = lambda x, y, dx, dy: (x, y)
 sys.modules["geometry"] = geo_stub
 
 # tension_calculation


### PR DESCRIPTION
## Summary
- provide `get_failed_wires` helper to collect wires that didn't pass tension
- implement `measure_failing` in the tensiometer
- add GUI entry point and button to remeasure failing wires
- adjust tests to stub `refine_position`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68507fb86f308329b1207d59e534f5c2