### PR TITLE
Implement randomized wiggle logic

### DIFF
--- a/src/dune_tension/tensiometer.py
+++ b/src/dune_tension/tensiometer.py
@@ -2,6 +2,7 @@ import threading
 from datetime import datetime
 from typing import Optional, Callable
 import time
+import random
 import numpy as np
 import pandas as pd
 from tension_calculation import calculate_kde_max, tension_plausible
@@ -277,14 +278,16 @@ class Tensiometer:
                 )
             if time.time() - wiggle_start_time > 1:
                 wiggle_start_time = time.time()
-                if last_amplitude is not None and amplitude < last_amplitude:
-
-                    plc_direction *= -1.0
-                    focus_direction *= -1
-                increment = plc_direction * current_wiggle
-                wire_y += increment
-                self.goto_xy_func(wire_x, wire_y)
-                self.focus_wiggle_func(focus_direction * 10)
+                if random.choice([True, False]):  # wiggle PLC
+                    if last_amplitude is not None and amplitude < last_amplitude:
+                        plc_direction *= -1.0
+                    increment = plc_direction * current_wiggle
+                    wire_y += increment
+                    self.goto_xy_func(wire_x, wire_y)
+                else:  # wiggle focus
+                    if last_amplitude is not None and amplitude < last_amplitude:
+                        focus_direction *= -1
+                    self.focus_wiggle_func(focus_direction * 10)
                 last_amplitude = amplitude
             if audio_sample is not None:
                 frequency, confidence, tension, tension_ok = analyze_sample(

--- a/tests/test_tensiometer.py
+++ b/tests/test_tensiometer.py
@@ -108,6 +108,7 @@ plc_stub.is_web_server_active = lambda: False
 plc_stub.spoof_get_xy = lambda: (0.0, 0.0)
 plc_stub.spoof_goto_xy = lambda x, y: True
 plc_stub.spoof_wiggle = lambda m: None
+plc_stub.increment = lambda x, y: None
 sys.modules["plc_io"] = plc_stub
 
 # data_cache


### PR DESCRIPTION
## Summary
- add `random` import for randomized wiggle logic
- pick a random servo (PLC or focus) to wiggle in `_collect_samples`
- provide `increment` in test stub to satisfy imports

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68508a937e4c8329b3a6305638649a6f