### PR TITLE
Non-blocking tension log updates

### DIFF
--- a/src/dune_tension/main.py
+++ b/src/dune_tension/main.py
@@ -348,19 +348,30 @@ def monitor_tension_logs():
     ):
         monitor_tension_logs.last_path = path
         monitor_tension_logs.last_mtime = mtime
-        try:
-            from analyze import update_tension_logs
+        def run() -> None:
+            try:
+                from analyze import update_tension_logs
 
-            update_tension_logs(config)
-            print(f"Updated tension logs for {config.apa_name} layer {config.layer}")
-        except Exception as exc:
-            print(f"Failed to update logs: {exc}")
+                update_tension_logs(config)
+                print(
+                    f"Updated tension logs for {config.apa_name} layer {config.layer}"
+                )
+            except Exception as exc:
+                print(f"Failed to update logs: {exc}")
+
+        if (
+            monitor_tension_logs.update_thread is None
+            or not monitor_tension_logs.update_thread.is_alive()
+        ):
+            monitor_tension_logs.update_thread = Thread(target=run, daemon=True)
+            monitor_tension_logs.update_thread.start()
 
     root.after(10000, monitor_tension_logs)
 
 
 monitor_tension_logs.last_path = ""
 monitor_tension_logs.last_mtime = None
+monitor_tension_logs.update_thread = None
 
 
 def manual_goto():

--- a/tests/test_main_dependencies.py
+++ b/tests/test_main_dependencies.py
@@ -242,15 +242,19 @@ def test_monitor_tension_logs(monkeypatch):
     main.monitor_tension_logs.last_path = ""
     main.monitor_tension_logs.last_mtime = None
     main.monitor_tension_logs()
+    main.monitor_tension_logs.update_thread.join(timeout=1)
     assert updates and updates[-1] is DummyConfig
     assert called_args["samples_per_wire"] == 5
     assert called_args["confidence_threshold"] == 0.9
     assert called_args["plot_audio"] is True
     assert main.monitor_tension_logs.last_mtime == 1
     main.monitor_tension_logs()
+    if main.monitor_tension_logs.update_thread is not None:
+        main.monitor_tension_logs.update_thread.join(timeout=1)
     assert len(updates) == 1
     monkeypatch.setattr(main.os.path, "getmtime", lambda p: 2)
     main.monitor_tension_logs()
+    main.monitor_tension_logs.update_thread.join(timeout=1)
     assert len(updates) == 2
 
 


### PR DESCRIPTION
## Summary
- run `update_tension_logs` in a background thread
- join background thread in `test_monitor_tension_logs`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6850913ebf148329931b223323e2b20e