### PR TITLE
Add manual tension input

### DIFF
--- a/tests/test_main_dependencies.py
+++ b/tests/test_main_dependencies.py
@@ -124,7 +124,14 @@ sys.modules["tensiometer_functions"] = tfunc_stub
 dc_stub = types.ModuleType("data_cache")
 dc_stub.clear_wire_range = lambda *a, **k: None
 dc_stub.clear_outliers = lambda *a, **k: []
+dc_stub.get_dataframe = lambda path: None
+dc_stub.update_dataframe = lambda path, df: None
 sys.modules["data_cache"] = dc_stub
+
+# Minimal results stub
+results_stub = types.ModuleType("results")
+results_stub.EXPECTED_COLUMNS = []
+sys.modules["results"] = results_stub
 
 import dune_tension.main as main
 from dune_tension.maestro import DummyController
@@ -344,11 +351,9 @@ def test_measure_condition_latest_only(monkeypatch):
         def __eq__(self, other):
             return Mask([v == other for v in self])
 
-
     class Mask(list):
         def __and__(self, other):
             return Mask([a and b for a, b in zip(self, other)])
-
 
     class DataFrame:
         def __init__(self, rows):
@@ -368,9 +373,7 @@ def test_measure_condition_latest_only(monkeypatch):
 
         def dropna(self, subset):
             self.rows = [
-                r
-                for r in self.rows
-                if all(r.get(k) is not None for k in subset)
+                r for r in self.rows if all(r.get(k) is not None for k in subset)
             ]
             return self
 

--- a/tests/test_tensiometer.py
+++ b/tests/test_tensiometer.py
@@ -35,6 +35,7 @@ numpy_stub.average = _avg
 numpy_stub.std = _std
 numpy_stub.linspace = _linspace
 numpy_stub.argmax = _argmax
+numpy_stub.bool_ = bool
 numpy_stub.isscalar = lambda x: not isinstance(x, (list, tuple))
 numpy_stub.savez = lambda *a, **k: None
 sys.modules["numpy"] = numpy_stub
@@ -119,6 +120,29 @@ dc_stub.get_samples_dataframe = lambda path: None
 dc_stub.update_samples_dataframe = lambda path, df: None
 dc_stub.EXPECTED_COLUMNS = []
 sys.modules["data_cache"] = dc_stub
+
+# results stub
+results_stub = types.ModuleType("results")
+
+
+class _Dummy:
+    def __init__(self, **kwargs):
+        for k, v in kwargs.items():
+            setattr(self, k, v)
+        freq = kwargs.get("frequency", 0.0)
+        if "tension" not in kwargs:
+            self.tension = freq * 0.1
+        self.tension_pass = kwargs.get("tension_pass", True)
+        self.wires = kwargs.get("wires", [])
+        self.zone = 1
+        self.wire_length = 1.0
+        self.t_sigma = _std(self.wires) if self.wires else 0.0
+
+
+results_stub.TensionResult = _Dummy
+results_stub.RawSample = _Dummy
+results_stub.EXPECTED_COLUMNS = []
+sys.modules["results"] = results_stub
 
 # tensiometer_functions
 tf_stub = types.ModuleType("tensiometer_functions")


### PR DESCRIPTION
## Summary
- add missing numpy stub attribute to tests
- add manual tension entry in GUI
- parse pairs of wire numbers and tensions to update the DB
- adjust tests for new imports

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686c26cac7c483299ecde2b0c6eb22ad