### PR TITLE
Add PLC locking and ensure resets

### DIFF
--- a/src/dune_tension/main.py
+++ b/src/dune_tension/main.py
@@ -170,6 +170,11 @@ def measure_calibrate():
                     t.close()
                 except Exception:
                     pass
+            try:
+                from plc_io import reset_plc
+                reset_plc()
+            except Exception:
+                pass
             stop_event.clear()
 
     Thread(target=run, daemon=True).start()
@@ -189,6 +194,11 @@ def measure_auto():
                     t.close()
                 except Exception:
                     pass
+            try:
+                from plc_io import reset_plc
+                reset_plc()
+            except Exception:
+                pass
             stop_event.clear()
 
     Thread(target=run, daemon=True).start()
@@ -214,6 +224,11 @@ def measure_list():
                     t.close()
                 except Exception:
                     pass
+            try:
+                from plc_io import reset_plc
+                reset_plc()
+            except Exception:
+                pass
             stop_event.clear()
 
     Thread(target=run, daemon=True).start()
@@ -291,6 +306,11 @@ def measure_condition() -> None:
                     t.close()
                 except Exception:
                     pass
+            try:
+                from plc_io import reset_plc
+                reset_plc()
+            except Exception:
+                pass
             stop_event.clear()
 
     Thread(target=run, daemon=True).start()

--- a/src/dune_tension/plc_io.py
+++ b/src/dune_tension/plc_io.py
@@ -3,6 +3,9 @@ import threading
 import time
 from random import gauss
 
+# Global lock to ensure exclusive PLC communication
+PLC_LOCK = threading.RLock()
+
 # Amount of travel, in mm, assumed to be lost when reversing X direction
 BACKLASH_DEADZONE = 0.5
 
@@ -49,7 +52,8 @@ def read_tag(tag_name, *, timeout: float = 10.0, retry_interval: float = 0.1) ->
 
     while time.monotonic() < end_time:
         try:
-            response = requests.get(url)
+            with PLC_LOCK:
+                response = requests.get(url)
             if response.status_code == 200:
                 try:
                     data = response.json()[tag_name]
@@ -107,7 +111,8 @@ def write_tag(tag_name, value):
     # print(f"Attempting to write to URL: {url}")  # Debugging statement
     payload = {"value": value}
     try:
-        response = requests.post(url, json=payload)
+        with PLC_LOCK:
+            response = requests.post(url, json=payload)
         if response.status_code == 200:
             return response.json()
         else:
@@ -119,7 +124,13 @@ def write_tag(tag_name, value):
         return {"error": str(e)}
 
 
-def goto_xy(x_target: float, y_target: float, *,speed=300, deadzone: float = BACKLASH_DEADZONE):
+def goto_xy(
+    x_target: float,
+    y_target: float,
+    *,
+    speed=300,
+    deadzone: float = BACKLASH_DEADZONE,
+):
     """Move the winder to a given position.
 
     When reversing X direction, assume the first ``deadzone`` mm of travel does
@@ -128,74 +139,80 @@ def goto_xy(x_target: float, y_target: float, *,speed=300, deadzone: float = BAC
 
     global _TRUE_XY, _LAST_X_DIR, _X_DEADZONE_LEFT
 
-    if not (1000 < x_target < 7174 and 0 < y_target < 2680):
-        print(
-            f"Motion target {x_target},{y_target} out of bounds. Please enter a valid position."
-        )
-        return False
+    with PLC_LOCK:
+        if not (1000 < x_target < 7174 and 0 < y_target < 2680):
+            print(
+                f"Motion target {x_target},{y_target} out of bounds. Please enter a valid position."
+            )
+            return False
 
-    # ------------------------------------------------------------
-    # Backlash compensation bookkeeping
-    # ------------------------------------------------------------
-    delta_x = x_target - _TRUE_XY[0]
-    direction = 1 if delta_x > 0 else -1 if delta_x < 0 else 0
+        # ------------------------------------------------------------
+        # Backlash compensation bookkeeping
+        # ------------------------------------------------------------
+        delta_x = x_target - _TRUE_XY[0]
+        direction = 1 if delta_x > 0 else -1 if delta_x < 0 else 0
 
-    if direction != 0 and direction != _LAST_X_DIR:
-        _X_DEADZONE_LEFT = deadzone
-        _LAST_X_DIR = direction
+        if direction != 0 and direction != _LAST_X_DIR:
+            _X_DEADZONE_LEFT = deadzone
+            _LAST_X_DIR = direction
 
-    move_x = abs(delta_x)
-    actual_move_x = 0.0
-    if direction != 0:
-        if _X_DEADZONE_LEFT > 0:
-            if move_x <= _X_DEADZONE_LEFT:
-                _X_DEADZONE_LEFT -= move_x
+        move_x = abs(delta_x)
+        actual_move_x = 0.0
+        if direction != 0:
+            if _X_DEADZONE_LEFT > 0:
+                if move_x <= _X_DEADZONE_LEFT:
+                    _X_DEADZONE_LEFT -= move_x
+                else:
+                    actual_move_x = direction * (move_x - _X_DEADZONE_LEFT)
+                    _X_DEADZONE_LEFT = 0.0
             else:
-                actual_move_x = direction * (move_x - _X_DEADZONE_LEFT)
-                _X_DEADZONE_LEFT = 0.0
-        else:
-            actual_move_x = delta_x
+                actual_move_x = delta_x
 
-    _TRUE_XY[0] += actual_move_x
-    _TRUE_XY[1] = y_target
+        _TRUE_XY[0] += actual_move_x
+        _TRUE_XY[1] = y_target
 
-    # ------------------------------------------------------------
-    # Command the PLC move
-    # ------------------------------------------------------------
-    current_state = get_state()
-    while current_state != IDLE_STATE:
-        time.sleep(0.1)
+        # ------------------------------------------------------------
+        # Command the PLC move
+        # ------------------------------------------------------------
         current_state = get_state()
-    set_speed(speed)
-    write_tag("MOVE_TYPE", IDLE_MOVE_TYPE)
-    write_tag("STATE", IDLE_STATE)
-    write_tag("X_POSITION", x_target)
-    write_tag("Y_POSITION", y_target)
-    write_tag("MOVE_TYPE", XY_MOVE_TYPE)
+        while current_state != IDLE_STATE:
+            time.sleep(0.1)
+            current_state = get_state()
+        set_speed(speed)
+        write_tag("MOVE_TYPE", IDLE_MOVE_TYPE)
+        write_tag("STATE", IDLE_STATE)
+        write_tag("X_POSITION", x_target)
+        write_tag("Y_POSITION", y_target)
+        write_tag("MOVE_TYPE", XY_MOVE_TYPE)
 
-    while get_movetype() == XY_MOVE_TYPE:
-        time.sleep(0.1)
-    return True
+        while get_movetype() == XY_MOVE_TYPE:
+            time.sleep(0.1)
+        return True
 
 def reset_plc():
     """Reset the PLC to its initial state."""
-    write_tag("MOVE_TYPE", IDLE_MOVE_TYPE)
-    write_tag("STATE", IDLE_STATE)
-    set_speed(0)  # Reset speed to a default value
+    with PLC_LOCK:
+        write_tag("MOVE_TYPE", IDLE_MOVE_TYPE)
+        write_tag("STATE", IDLE_STATE)
+        set_speed(0)  # Reset speed to a default value
 
 def increment(increment_x, increment_y):
     # Use the cached position to avoid reading tags when possible
-    x, y = get_cached_xy()
-    goto_xy(x + increment_x, y + increment_y)
+    with PLC_LOCK:
+        x, y = get_cached_xy()
+        goto_xy(x + increment_x, y + increment_y)
 
 
 def wiggle(step):
     """Wiggle the winder by a given step size in a background thread."""
 
     def _do_wiggle() -> None:
-        y_wiggle = gauss(0, step)
-        increment(0, y_wiggle)
-        print(f"Wiggling by {y_wiggle} mm")
+        try:
+            y_wiggle = gauss(0, step)
+            increment(0, y_wiggle)
+            print(f"Wiggling by {y_wiggle} mm")
+        finally:
+            reset_plc()
 
     threading.Thread(target=_do_wiggle, daemon=True).start()
     return True
@@ -209,7 +226,8 @@ def set_speed(speed: float = 300) -> bool:
         print(f"Speed {speed} out of bounds. Please enter a value between 0 and 100.")
         return False
 
-    response = write_tag("XY_SPEED", speed)
+    with PLC_LOCK:
+        response = write_tag("XY_SPEED", speed)
     if "error" in response:
         print(f"Failed to set speed: {response['error']}")
         return False

--- a/src/dune_tension/tensiometer.py
+++ b/src/dune_tension/tensiometer.py
@@ -131,14 +131,15 @@ class Tensiometer:
         self._wiggle_event.set()
 
         start_x, start_y = self.get_current_xy_position()
-        wiggle_width = abs(getattr(self.config, "dy", 4.0)/3)
+        # Wiggle by roughly half the wire pitch to avoid hitting adjacent wires
+        wiggle_width = abs(getattr(self.config, "dy", 2.0) / 2)
         def _run() -> None:
             while self._wiggle_event and self._wiggle_event.is_set():
 
-                self.goto_xy_func(start_x, start_y-wiggle_width,speed=wiggle_width)
+                self.goto_xy_func(start_x, start_y - wiggle_width, speed=wiggle_width)
                 if self._wiggle_event is not None and not self._wiggle_event.is_set():
                     break
-                self.goto_xy_func(start_x, start_y+wiggle_width,speed=wiggle_width)
+                self.goto_xy_func(start_x, start_y + wiggle_width, speed=wiggle_width)
                 time.sleep(0.01)
 
         self._wiggle_thread = threading.Thread(target=_run, daemon=True)
@@ -526,6 +527,7 @@ class Tensiometer:
             self._focus_direction = focus_dir
         finally:
             self.stop_servo_loop()
+            reset_plc()
 
         if wires is None:
             return


### PR DESCRIPTION
## Summary
- prevent concurrent PLC access by introducing a global lock
- reset the PLC at the end of any PLC-using thread
- guarantee the winder wiggle uses half-pitch motion and resets the PLC
- run reset_plc after measurement threads finish

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686d8a2a1d008329b46148d1117e227f