### PR TITLE
Add optional profiling to measure_list

### DIFF
--- a/src/dune_tension/tensiometer.py
+++ b/src/dune_tension/tensiometer.py
@@ -296,7 +296,9 @@ class Tensiometer:
                 )
         print("Done measuring all wires")
 
-    def measure_list(self, wire_list: list[int], preserve_order: bool) -> None:
+    def measure_list(
+        self, wire_list: list[int], preserve_order: bool, profile: bool = False
+    ) -> None:
         measure_list(
             config=self.config,
             wire_list=wire_list,
@@ -309,6 +311,7 @@ class Tensiometer:
             ),
             stop_event=self.stop_event,
             preserve_order=preserve_order,
+            profile=profile,
         )
 
     def _collect_samples(


### PR DESCRIPTION
## Summary
- allow profiling of wire measurement sequences with a new `profile` flag
- surface profiling through Tensiometer.measure_list so callers can enable performance analysis

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68938484f6348329b0dcb747f3b14bc6