### PR TITLE
Support dash-separated wire ranges in GUI measurement

### DIFF
--- a/src/dune_tension/main.py
+++ b/src/dune_tension/main.py
@@ -210,11 +210,10 @@ def measure_list():
         t = None
         try:
             t = create_tensiometer()
-            wire_list = [
-                int(w.strip())
-                for w in entry_wire_list.get().split(",")
-                if w.strip().isdigit()
-            ]
+            ranges = _parse_ranges(entry_wire_list.get())
+            wire_list: list[int] = []
+            for start, end in ranges:
+                wire_list.extend(range(start, end + 1))
             save_state()
             print(f"Measuring wires: {wire_list}")
             t.measure_list(wire_list, preserve_order=False)


### PR DESCRIPTION
## Summary
- Expand GUI `measure_list` to parse comma and dash separated ranges, converting inputs like `8-20` into an inclusive list of wires
- Add regression test for range parsing

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a345b1b3d883299c0bff3a89f07129