### PR TITLE
Load spectrogram scroller defaults from JSON config

### DIFF
--- a/src/spectrum_analysis/cli.py
+++ b/src/spectrum_analysis/cli.py
@@ -1,45 +1,82 @@
 """Command-line entrypoints for the spectrogram scroller."""
+
 from __future__ import annotations
 
 import argparse
+import json
+from importlib import resources
+from typing import Any
 
 from .audio import DemoSource, MicSource, sd
 from .visualizer import ScrollingSpectrogram, SpectrogramConfig
 
+_SCROLLER_CONFIG_NAME = "spectrogram_scroller_basic_config.json"
+
+
+def load_scroller_config() -> dict[str, Any]:
+    """Load the default configuration for the spectrogram scroller."""
+
+    config_path = resources.files(__package__).joinpath(_SCROLLER_CONFIG_NAME)
+    with config_path.open("r", encoding="utf-8") as handle:
+        return json.load(handle)
+
 
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    defaults = load_scroller_config()
     parser = argparse.ArgumentParser(
         description="Scrolling Spectrogram + Spectrum + Autocorrelation views"
     )
-    parser.add_argument("--samplerate", type=int, default=44100)
-    parser.add_argument("--fft", type=int, default=8192)
-    parser.add_argument("--hop", type=int, default=512)
-    parser.add_argument("--window", type=float, default=5.0)
-    parser.add_argument("--max-freq", type=float, default=2000.0)
-    parser.add_argument("--db-range", type=float, default=80.0)
+    parser.add_argument(
+        "--samplerate", type=int, default=int(defaults.get("samplerate", 44100))
+    )
+    parser.add_argument("--fft", type=int, default=int(defaults.get("fft_size", 8192)))
+    parser.add_argument("--hop", type=int, default=int(defaults.get("hop", 512)))
+    parser.add_argument(
+        "--window", type=float, default=float(defaults.get("window_sec", 5.0))
+    )
+    parser.add_argument(
+        "--max-freq", type=float, default=float(defaults.get("max_freq", 2000.0))
+    )
+    parser.add_argument(
+        "--db-range", type=float, default=float(defaults.get("db_range", 80.0))
+    )
     parser.add_argument("--device", type=str, default=None)
     parser.add_argument("--demo", action="store_true")
-    parser.add_argument("--noise-sec", type=float, default=2.0)
-    parser.add_argument("--over-sub", type=float, default=1.0)
-    parser.add_argument("--no-noise-filter", action="store_true")
-    parser.add_argument("--min-freq", type=float, default=10.0)
+    parser.add_argument(
+        "--noise-sec", type=float, default=float(defaults.get("noise_sec", 2.0))
+    )
+    parser.add_argument(
+        "--over-sub", type=float, default=float(defaults.get("over_sub", 1.0))
+    )
+    parser.add_argument(
+        "--no-noise-filter",
+        action="store_true",
+        default=not bool(defaults.get("enable_noise_filter", True)),
+    )
+    parser.add_argument(
+        "--min-freq", type=float, default=float(defaults.get("min_freq", 10.0))
+    )
     return parser.parse_args(argv)
 
 
 def build_config(args: argparse.Namespace) -> SpectrogramConfig:
-    return SpectrogramConfig(
-        samplerate=args.samplerate,
-        fft_size=args.fft,
-        hop=args.hop,
-        window_sec=args.window,
-        max_freq=args.max_freq,
-        db_range=args.db_range,
-        enable_noise_filter=not args.no_noise_filter,
-        noise_sec=args.noise_sec,
-        over_sub=args.over_sub,
-        min_freq=args.min_freq,
-        ac_win_sec=0.5,
+    defaults = load_scroller_config()
+    config_kwargs = dict(defaults)
+    config_kwargs.update(
+        {
+            "samplerate": args.samplerate,
+            "fft_size": args.fft,
+            "hop": args.hop,
+            "window_sec": args.window,
+            "max_freq": args.max_freq,
+            "db_range": args.db_range,
+            "enable_noise_filter": not args.no_noise_filter,
+            "noise_sec": args.noise_sec,
+            "over_sub": args.over_sub,
+            "min_freq": args.min_freq,
+        }
     )
+    return SpectrogramConfig(**config_kwargs)
 
 
 def create_source(args: argparse.Namespace):

--- a/src/spectrum_analysis/spectrogram_scroller_basic_config.json
+++ b/src/spectrum_analysis/spectrogram_scroller_basic_config.json
@@ -1,0 +1,16 @@
+{
+  "samplerate": 44100,
+  "fft_size": 8192,
+  "hop": 512,
+  "window_sec": 5.0,
+  "max_freq": 2000.0,
+  "db_range": 80.0,
+  "enable_noise_filter": true,
+  "noise_sec": 2.0,
+  "over_sub": 1.0,
+  "min_freq": 10.0,
+  "ac_win_sec": 0.5,
+  "snr_trigger": 3.0,
+  "snr_release": 3.0,
+  "pre_record_sec": 0.1
+}


### PR DESCRIPTION
## Summary
- add configuration for RMS/SNR trigger levels and a 0.1 s pre-record buffer
- gate spectrogram updates on the trigger, buffering audio until the SNR exceeds the threshold and freezing plots after capture
- compute averaged spectrum/ACF/FACF results over the full recorded frame and reuse the profiled noise floor to estimate the trigger RMS
- load the spectrogram scroller defaults from `spectrum_analysis/spectrogram_scroller_basic_config.json` so CLI defaults and runtime parameters live outside the code

## Testing
- not run (pytest requires pandas in the GUI test harness)


------
https://chatgpt.com/codex/tasks/task_e_68d809acd5148329a43c6a508397707b