### PR TITLE
Remove duplicate spectrogram scroller entrypoint

### DIFF
--- a/src/spectrogram_scroller_basic.py
+++ b/src/spectrogram_scroller_basic.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Legacy entrypoint for the scrolling spectrogram visualizer."""
+"""Canonical entry point for the scrolling spectrogram visualizer."""
 
 from spectrum_analysis.cli import main
 

--- a/src/spectrum_analysis/spectrogram_scroller_basic.py
+++ b/src/spectrum_analysis/spectrogram_scroller_basic.py
@@ -1,8 +1,0 @@
-#!/usr/bin/env python3
-"""Legacy entrypoint for the scrolling spectrogram visualizer."""
-
-from cli import main
-
-
-if __name__ == "__main__":
-    main()


### PR DESCRIPTION
## Summary
- remove the redundant `spectrogram_scroller_basic.py` copy from `src/spectrum_analysis`
- clarify that `src/spectrogram_scroller_basic.py` is the canonical entry point for the visualizer

## Testing
- not run (script-only change)


------
https://chatgpt.com/codex/tasks/task_e_68d81314cd44832987067c576a7833da