### PR TITLE
Add spoofed CREPE activation plot

### DIFF
--- a/src/spectrum_analysis/pitch_compare_config.json
+++ b/src/spectrum_analysis/pitch_compare_config.json
@@ -13,5 +13,6 @@
   "show_plots": true,
   "crepe_model_capacity": "tiny",
   "pesto_model_name": "mir-1k_g7",
-  "over_subtraction": 1.1
+  "over_subtraction": 1.1,
+  "spoof factor": 2.0
 }


### PR DESCRIPTION
## Summary
- add a spoof factor configuration option and load it from the JSON config
- generate CREPE activations for both the real and spoofed sample rates and present them side by side
- update the default pitch comparison config to include the spoof factor entry

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d8321dfa088329b5ff10afe47d9a5c