### PR TITLE
Filter unvoiced frames from CREPE legend stats

### DIFF
--- a/src/spectrum_analysis/compare_pitch_cli.py
+++ b/src/spectrum_analysis/compare_pitch_cli.py
@@ -9,6 +9,7 @@ import json
 from pathlib import Path
 from typing import Any, Dict, Iterable, List, Optional, Tuple
 import matplotlib.pyplot as plt
+from matplotlib.lines import Line2D
 import numpy as np
 from scipy import signal
 from scipy.io import wavfile
@@ -375,6 +376,41 @@ def plot_results(
                     ha="center",
                     va="center",
                     transform=ax.transAxes,
+                )
+            if crepe_act.size:
+                voiced_threshold = 0.5
+                frame_confidence = crepe_act.max(axis=1)
+                voiced_mask = frame_confidence >= voiced_threshold
+
+                average_activations = (
+                    crepe_act[voiced_mask].mean(axis=0, keepdims=True)
+                    if voiced_mask.any()
+                    else None
+                )
+
+                if (
+                    average_activations is not None
+                    and np.isfinite(average_activations).all()
+                ):
+                    cents = crepe.core.to_local_average_cents(average_activations)
+                    frequency = 10 * 2 ** (cents / 1200.0)
+                    confidence = average_activations.max(axis=1)
+
+                    freq_value = float(np.squeeze(frequency))
+                    conf_value = float(np.squeeze(confidence))
+
+                    if not np.isfinite(freq_value):
+                        freq_value = 0.0
+                    if not np.isfinite(conf_value):
+                        conf_value = 0.0
+
+                    legend_label = f"Fundamental: {freq_value:.2f} Hz\nConfidence: {conf_value:.3f}"
+                else:
+                    legend_label = "Fundamental: N/A\nConfidence: N/A"
+
+                dummy_handle = Line2D([], [], color="none")
+                ax.legend(
+                    [dummy_handle], [legend_label], loc="upper right", frameon=True
                 )
         else:
             ax.text(


### PR DESCRIPTION
## Summary
- filter the CREPE activation averaging to frames whose per-frame confidence meets the voiced threshold
- show an N/A legend when no voiced frames pass the threshold to avoid misleading metrics

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d8489431988329a9e3a638b7026868