### PR TITLE
Scale augmented CREPE activation times

### DIFF
--- a/src/spectrum_analysis/crepe_analysis.py
+++ b/src/spectrum_analysis/crepe_analysis.py
@@ -65,6 +65,8 @@ def compute_crepe_activation(
 
     frame_count = activation.shape[0]
     crepe_times = np.arange(frame_count) * step_ms / 1000.0
+    if sr_augment_factor is not None:
+        crepe_times = crepe_times * sr_augment_factor
     return (
         np.asarray(crepe_times, dtype=np.float32),
         np.asarray(activation, dtype=np.float32),


### PR DESCRIPTION
## Summary
- scale CREPE activation timeline by the sample-rate augment factor so augmented plots show the correct time axis

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d887c22af08329b12325137901dbc5