### PR TITLE
Add CREPE activation coverage-based auto-cropping

### DIFF
--- a/src/spectrum_analysis/pitch_compare_config.json
+++ b/src/spectrum_analysis/pitch_compare_config.json
@@ -14,5 +14,6 @@
   "crepe_model_capacity": "tiny",
   "pesto_model_name": "mir-1k_g7",
   "over_subtraction": 1.1,
-  "sr_augment_factor": 20
+  "sr_augment_factor": 20,
+  "crepe_activation_coverage": 0.99
 }


### PR DESCRIPTION
## Summary
- add a configuration option to specify the CREPE activation coverage threshold, defaulting to 99%
- compute the smallest bottom-left aligned rectangle covering the requested activation mass and limit the CREPE plot axes accordingly

## Testing
- pytest *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_68d88ad9d8fc832980566bc5f45bb53e