### PR TITLE
Handle missing spectrogram power and refine CREPE cropping

### DIFF
--- a/src/spectrum_analysis/pitch_compare_config.json
+++ b/src/spectrum_analysis/pitch_compare_config.json
@@ -14,5 +14,6 @@
   "crepe_model_capacity": "tiny",
   "pesto_model_name": "mir-1k_g7",
   "over_subtraction": 1.1,
-  "sr_augment_factor": 20
+  "sr_augment_factor": 20,
+  "crepe_activation_coverage": 0.9
 }


### PR DESCRIPTION
## Summary
- default the CREPE activation coverage threshold to 90% and clamp invalid values
- compute bottom-left crop bounds using positive activation sums so the requested coverage is honored
- skip spectrogram rendering gracefully when spectral power is unavailable

## Testing
- pytest *(fails: ModuleNotFoundError: No module named 'pandas')*


------
https://chatgpt.com/codex/tasks/task_e_68d88ad9d8fc832980566bc5f45bb53e