### PR TITLE
Default CREPE sr augmentation to 1 when expected f0 missing

### DIFF
--- a/src/spectrum_analysis/compare_pitch_cli.py
+++ b/src/spectrum_analysis/compare_pitch_cli.py
@@ -54,13 +54,23 @@ class PitchCompareConfig:
     crepe_model_capacity: str = "full"
     crepe_step_size_ms: Optional[float] = None
     over_subtraction: float = 1.0  # Noise reduction factor
-    sr_augment_factor: float = 2.0  # Factor to scale sample rate for CREPE
+    expected_f0: Optional[float] = (
+        None  # Expected fundamental frequency for CREPE scaling
+    )
     crepe_activation_coverage: float = 0.9
 
     @staticmethod
     def from_dict(raw: Dict[str, Any]) -> "PitchCompareConfig":
-        alias_map = {"sr_augment_factor": "sr_augment_factor"}
-        normalized = {alias_map.get(k, k): v for k, v in raw.items()}
+        normalized = dict(raw)
+
+        if "expected_f0" not in normalized and "sr_augment_factor" in normalized:
+            try:
+                sr_factor = float(normalized["sr_augment_factor"])
+            except (TypeError, ValueError):
+                sr_factor = float("nan")
+            if np.isfinite(sr_factor) and sr_factor > 0:
+                normalized["expected_f0"] = 1000.0 / sr_factor
+
         known = {f.name for f in dataclasses.fields(PitchCompareConfig)}
         filtered = {k: v for k, v in normalized.items() if k in known}
         return PitchCompareConfig(**filtered)
@@ -436,10 +446,14 @@ def main(argv: Optional[Iterable[str]] = None) -> None:
     real_label = f"CREPE Activation ({cfg.sample_rate} Hz Real)"
     crepe_results.append((real_label, crepe_real))
 
-    sr_augment_factor = cfg.sr_augment_factor
-    if not np.isfinite(sr_augment_factor) or sr_augment_factor <= 0:
-        print("[WARN] Invalid augment factor; defaulting to 1.0.")
+    expected_f0 = cfg.expected_f0
+    if expected_f0 is None:
         sr_augment_factor = 1.0
+    elif not np.isfinite(expected_f0) or expected_f0 <= 0:
+        print("[WARN] Invalid expected f0; defaulting augment factor to 1.0.")
+        sr_augment_factor = 1.0
+    else:
+        sr_augment_factor = 1000.0 / expected_f0
     augmented_sr = (
         int(round(cfg.sample_rate * sr_augment_factor))
         if sr_augment_factor

--- a/src/spectrum_analysis/pitch_compare_config.json
+++ b/src/spectrum_analysis/pitch_compare_config.json
@@ -14,6 +14,6 @@
   "crepe_model_capacity": "tiny",
   "pesto_model_name": "mir-1k_g7",
   "over_subtraction": 1.1,
-  "sr_augment_factor": 4,
+  "expected_f0": 250.0,
   "crepe_activation_coverage": 0.9
 }


### PR DESCRIPTION
## Summary
- allow `expected_f0` to be omitted in the pitch comparison config by defaulting the derived CREPE sample-rate augmentation to 1x
- keep the invalid-value guardrails for `expected_f0` so non-positive inputs still fall back to the neutral scaling

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d8963278508329951403f19dedddfc