### PR TITLE
Focus CREPE crop on bottom-left coverage

### DIFF
--- a/src/spectrum_analysis/compare_pitch_cli.py
+++ b/src/spectrum_analysis/compare_pitch_cli.py
@@ -55,6 +55,7 @@ class PitchCompareConfig:
     crepe_step_size_ms: Optional[float] = None
     over_subtraction: float = 1.0  # Noise reduction factor
     sr_augment_factor: float = 2.0  # Factor to scale sample rate for CREPE
+    crepe_activation_coverage: float = 0.9
 
     @staticmethod
     def from_dict(raw: Dict[str, Any]) -> "PitchCompareConfig":
@@ -165,7 +166,7 @@ def plot_results(
     audio: np.ndarray,
     freqs: np.ndarray,
     times: np.ndarray,
-    power: np.ndarray,
+    power: Optional[np.ndarray],
     crepe_results: List[Tuple[str, Optional[Tuple[np.ndarray, np.ndarray]]]],
     cfg: PitchCompareConfig,
     output_dir: Path,
@@ -204,17 +205,31 @@ def _add_spectrogram_plot(
     location: slice,
     freqs: np.ndarray,
     times: np.ndarray,
-    power: np.ndarray,
+    power: Optional[np.ndarray],
     cfg: PitchCompareConfig,
 ) -> Axes:
     ax = fig.add_subplot(location)
-    mesh = ax.pcolormesh(
-        times, freqs, 10 * np.log10(power + 1e-12), shading="gouraud", cmap="magma"
-    )
+    if power is None:
+        ax.text(
+            0.5,
+            0.5,
+            "Spectrogram unavailable.",
+            ha="center",
+            va="center",
+            transform=ax.transAxes,
+        )
+    else:
+        mesh = ax.pcolormesh(
+            times,
+            freqs,
+            10 * np.log10(np.asarray(power, dtype=float) + 1e-12),
+            shading="gouraud",
+            cmap="magma",
+        )
+        fig.colorbar(mesh, ax=ax, label="Power (dB)")
     ax.set_ylim(cfg.min_frequency, cfg.max_frequency)
     ax.set_ylabel("Frequency (Hz)")
     ax.set_title("Spectrogram (Noise-Reduced)")
-    fig.colorbar(mesh, ax=ax, label="Power (dB)")
     return ax
 
 
@@ -240,11 +255,17 @@ def _render_crepe_axis(
     result: Optional[Tuple[np.ndarray, np.ndarray]],
     cfg: PitchCompareConfig,
 ) -> None:
+    x_limits: Optional[Tuple[float, float]] = None
+    y_limits: Optional[Tuple[float, float]] = None
     if result is not None:
         crepe_times, crepe_act = result
         freq_axis = crepe_frequency_axis(crepe_act.shape[1])
         mask = (freq_axis >= cfg.min_frequency) & (freq_axis <= cfg.max_frequency)
         if mask.any():
+            coverage = getattr(cfg, "crepe_activation_coverage", 0.9)
+            if not np.isfinite(coverage):
+                coverage = 1.0
+            coverage = float(np.clip(coverage, 0.0, 1.0))
             mesh = ax.pcolormesh(
                 crepe_times,
                 freq_axis[mask],
@@ -253,6 +274,19 @@ def _render_crepe_axis(
                 cmap="viridis",
             )
             fig.colorbar(mesh, ax=ax, label="Activation")
+
+            masked_activation = crepe_act[:, mask]
+            freq_values = freq_axis[mask]
+            limits = _compute_crepe_crop_limits(
+                crepe_times,
+                freq_values,
+                masked_activation,
+                coverage,
+                cfg.min_frequency,
+                cfg.max_frequency,
+            )
+            if limits is not None:
+                x_limits, y_limits = limits
         else:
             ax.text(
                 0.5,
@@ -262,6 +296,11 @@ def _render_crepe_axis(
                 va="center",
                 transform=ax.transAxes,
             )
+
+        if x_limits is None and crepe_times.size:
+            x_limits = (crepe_times[0], crepe_times[-1])
+        if y_limits is None:
+            y_limits = (cfg.min_frequency, cfg.max_frequency)
 
         legend_label = _activation_summary_label(crepe_act)
         dummy_handle = Line2D([], [], color="none")
@@ -275,11 +314,76 @@ def _render_crepe_axis(
             va="center",
             transform=ax.transAxes,
         )
+        y_limits = (cfg.min_frequency, cfg.max_frequency)
 
-    ax.set_ylim(cfg.min_frequency, cfg.max_frequency)
+    if x_limits is not None:
+        ax.set_xlim(*x_limits)
+    if y_limits is not None:
+        ax.set_ylim(*y_limits)
     ax.set_ylabel("Frequency (Hz)")
     ax.set_xlabel("Time (s)")
     ax.set_title(label or "CREPE Activation")
+
+
+def _compute_crepe_crop_limits(
+    times: np.ndarray,
+    freqs: np.ndarray,
+    activation: np.ndarray,
+    coverage: float,
+    min_frequency: float,
+    max_frequency: float,
+) -> Optional[Tuple[Tuple[float, float], Tuple[float, float]]]:
+    if activation.size == 0 or times.size == 0 or freqs.size == 0:
+        return None
+
+    coverage = float(np.clip(coverage, 0.0, 1.0))
+    positive_activation = np.where(activation > 0.0, activation, 0.0)
+    total_activation = float(positive_activation.sum())
+    if total_activation <= 0.0 or coverage <= 0.0:
+        return None
+
+    min_time = float(times[0])
+    max_time = float(times[-1]) if times.size else min_time
+    min_freq = float(min_frequency)
+    max_freq = float(max_frequency)
+
+    if coverage >= 1.0:
+        return (min_time, max_time), (min_freq, max_freq)
+
+    cumulative = np.cumsum(np.cumsum(positive_activation, axis=0), axis=1)
+    target = coverage * total_activation
+    coverage_mask = cumulative >= target
+    if not coverage_mask.any():
+        return None
+
+    candidate_indices = np.argwhere(coverage_mask)
+    areas = (candidate_indices[:, 0] + 1) * (candidate_indices[:, 1] + 1)
+    min_area = np.min(areas)
+    smallest = candidate_indices[areas == min_area]
+    order = np.lexsort((smallest[:, 1], smallest[:, 0]))
+    best_idx = smallest[order[0]]
+    time_idx = int(best_idx[0])
+    freq_idx = int(best_idx[1])
+
+    if times.size == 1:
+        time_limit = float(times[0])
+    else:
+        time_limit = float(times[min(time_idx + 1, times.size - 1)])
+
+    if freqs.size == 1:
+        freq_limit = float(freqs[0])
+    else:
+        freq_limit = float(freqs[min(freq_idx + 1, freqs.size - 1)])
+
+    time_limit = float(np.clip(time_limit, min_time, max_time))
+    freq_limit = float(np.clip(freq_limit, min_freq, max_freq))
+
+    if time_limit <= min_time and times.size > 1:
+        time_limit = float(times[1])
+    if freq_limit <= min_freq and freqs.size > 1:
+        freq_limit = float(freqs[1])
+
+    return (min_time, time_limit), (min_freq, freq_limit)
 
 
 def _activation_summary_label(activation: np.ndarray) -> str:

--- a/src/spectrum_analysis/pitch_compare_config.json
+++ b/src/spectrum_analysis/pitch_compare_config.json
@@ -14,5 +14,6 @@
   "crepe_model_capacity": "tiny",
   "pesto_model_name": "mir-1k_g7",
   "over_subtraction": 1.1,
-  "sr_augment_factor": 20
+  "sr_augment_factor": 20,
+  "crepe_activation_coverage": 0.9
 }


### PR DESCRIPTION
## Summary
- compute the bottom-left aligned CREPE crop that reaches the configured activation coverage using activation magnitudes
- tighten the CREPE axis limits by removing the previous margin expansion while clamping to the configured frequency range

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d88ad9d8fc832980566bc5f45bb53e