### PR TITLE
Fix spectrogram handling for file input in pitch comparison CLI

### DIFF
--- a/src/spectrum_analysis/audio_processing.py
+++ b/src/spectrum_analysis/audio_processing.py
@@ -126,6 +126,24 @@ def compute_noise_profile(
     return freqs, times, power
 
 
+def compute_spectrogram(
+    audio: np.ndarray, cfg: "PitchCompareConfig"
+) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+    """Compute a magnitude spectrogram for ``audio``."""
+
+    win_len, hop_len = determine_window_and_hop(cfg, len(audio))
+    freqs, times, stft = signal.stft(
+        audio,
+        fs=cfg.sample_rate,
+        window="hann",
+        nperseg=win_len,
+        noverlap=win_len - hop_len,
+        padded=False,
+    )
+    power = np.abs(stft) ** 2
+    return freqs, times, power
+
+
 def subtract_noise(
     audio: np.ndarray, noise_profile: np.ndarray, cfg: "PitchCompareConfig"
 ) -> tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]:


### PR DESCRIPTION
## Summary
- add a reusable helper to compute spectrograms without noise reduction
- ensure file inputs still compute a spectrogram while skipping noise subtraction
- update the spectrogram title to reflect whether noise reduction was applied

## Testing
- No automated tests were run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68d89d8140048329b74790194be37f87