### PR TITLE
Weight CREPE confidence by frame duration

### DIFF
--- a/src/spectrum_analysis/compare_pitch_cli.py
+++ b/src/spectrum_analysis/compare_pitch_cli.py
@@ -392,7 +392,7 @@ def _render_crepe_axis(
         if y_limits is None:
             y_limits = (cfg.min_frequency, cfg.max_frequency)
 
-        legend_label = _activation_summary_label(crepe_act.T)
+        legend_label = _activation_summary_label(crepe_times, freq_axis, crepe_act.T)
         ax.text(
             1.02,
             0.0,
@@ -488,8 +488,12 @@ def _compute_crepe_crop_limits(
     return (min_time, time_limit), (min_freq, freq_limit)
 
 
-def _activation_summary_label(activation: np.ndarray) -> str:
-    freq_value, conf_value = activation_to_frequency_confidence(activation)
+def _activation_summary_label(
+    times: np.ndarray, freq_axis: np.ndarray, activation: np.ndarray
+) -> str:
+    freq_value, conf_value = activation_to_frequency_confidence(
+        activation, times, freq_axis
+    )
     if not np.isfinite(freq_value) or not np.isfinite(conf_value):
         return "Fundamental: N/A\nConfidence: N/A"
     return f"Fundamental: {freq_value:.2f} Hz\nConfidence: {conf_value:.3f}"

--- a/src/spectrum_analysis/crepe_analysis.py
+++ b/src/spectrum_analysis/crepe_analysis.py
@@ -92,26 +92,83 @@ def _reverse_sr_augment(activation: np.ndarray, sr_augment_factor: float) -> np.
     return activation
 
 
-def activation_to_frequency_confidence(activation: np.ndarray) -> Tuple[float, float]:
-    """Return fundamental frequency and confidence summary for an activation map."""
+def activation_to_frequency_confidence(
+    activation: np.ndarray,
+    times: np.ndarray,
+    freq_axis: Optional[np.ndarray] = None,
+) -> Tuple[float, float]:
+    """Return fundamental frequency and time-weighted confidence for an activation map.
 
-    if crepe is None:
-        return float("nan"), float("nan")
+    Parameters
+    ----------
+    activation:
+        A two-dimensional array of CREPE activations with shape ``(T, F)`` where ``T`` is
+        the number of frames and ``F`` is the number of frequency bins.
+    times:
+        A one-dimensional array of time centers for each activation frame with shape
+        ``(T,)``. Durations are computed from adjacent time differences with the final
+        frame assigned the same duration as the previous interval.
+    freq_axis:
+        Optional frequency bin centers with shape ``(F,)`` used to compute a weighted
+        average when the CREPE dependency is unavailable.
+    """
 
     if activation.size == 0:
         return float("nan"), float("nan")
 
-    voiced_mask = activation.max(axis=1) > 0
+    times = np.asarray(times, dtype=np.float64)
+    if times.ndim != 1 or times.size != activation.shape[0]:
+        return float("nan"), float("nan")
+
+    if times.size == 0:
+        return float("nan"), float("nan")
+
+    durations = np.zeros_like(times, dtype=np.float64)
+    if times.size > 1:
+        frame_intervals = np.diff(times)
+        # Use the previous interval for the final frame to approximate its duration.
+        durations[:-1] = frame_intervals
+        durations[-1] = frame_intervals[-1]
+    else:
+        durations[0] = 0.0
+
+    durations = np.clip(durations, 0.0, None)
+
+    voiced_mask = (activation.max(axis=1) > 0) & (durations > 0)
     if not np.any(voiced_mask):
         return float("nan"), float("nan")
 
-    average_activations = activation[voiced_mask].mean(axis=0, keepdims=True)
-    cents = crepe.core.to_local_average_cents(average_activations)
-    frequency = 10 * 2 ** (cents / 1200.0)
-    confidence = average_activations.max(axis=1)
+    valid_durations = durations[voiced_mask]
+    weighted_activation = activation[voiced_mask] * valid_durations[:, np.newaxis]
+    total_duration = float(valid_durations.sum())
+    if total_duration <= 0.0:
+        return float("nan"), float("nan")
 
-    freq_value = float(np.squeeze(frequency))
-    conf_value = float(np.squeeze(confidence))
+    average_activations = (
+        np.sum(weighted_activation, axis=0, keepdims=True) / total_duration
+    )
+
+    if crepe is not None:
+        cents = crepe.core.to_local_average_cents(average_activations)
+        frequency = 10 * 2 ** (cents / 1200.0)
+        freq_value = float(np.squeeze(frequency))
+    elif freq_axis is not None:
+        freq_axis = np.asarray(freq_axis, dtype=np.float64)
+        if freq_axis.ndim != 1 or freq_axis.size != activation.shape[1]:
+            freq_value = float("nan")
+        else:
+            activation_sum = float(np.sum(average_activations))
+            if activation_sum <= 0.0:
+                freq_value = float("nan")
+            else:
+                freq_value = float(
+                    np.dot(freq_axis, average_activations.ravel()) / activation_sum
+                )
+    else:
+        freq_value = float("nan")
+
+    frame_confidences = activation[voiced_mask].max(axis=1)
+    conf_value = float(np.dot(frame_confidences, valid_durations))
     return freq_value, conf_value
 
 

--- a/tests/test_crepe_analysis.py
+++ b/tests/test_crepe_analysis.py
@@ -1,0 +1,56 @@
+from pathlib import Path
+import sys
+
+import numpy as np
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+
+from spectrum_analysis import crepe_analysis
+
+
+def test_activation_to_frequency_confidence_time_weighting(monkeypatch):
+    monkeypatch.setattr(crepe_analysis, "crepe", None)
+
+    activation = np.array(
+        [
+            [0.2, 0.8],
+            [0.4, 0.6],
+        ],
+        dtype=np.float32,
+    )
+    times = np.array([0.0, 0.1], dtype=np.float32)
+    freq_axis = np.array([100.0, 200.0], dtype=np.float32)
+
+    freq, confidence = crepe_analysis.activation_to_frequency_confidence(
+        activation, times, freq_axis
+    )
+
+    expected_confidence = (0.8 * 0.1) + (0.6 * 0.1)
+    assert np.isfinite(freq)
+    assert np.isclose(confidence, expected_confidence)
+
+    weighted_bins = np.array([0.02 + 0.04, 0.08 + 0.06])
+    expected_freq = np.dot(freq_axis, weighted_bins) / weighted_bins.sum()
+    assert np.isclose(freq, expected_freq)
+
+
+def test_activation_to_frequency_confidence_last_duration(monkeypatch):
+    monkeypatch.setattr(crepe_analysis, "crepe", None)
+
+    activation = np.array(
+        [
+            [0.0, 0.0],
+            [0.1, 0.9],
+            [0.3, 0.7],
+        ],
+        dtype=np.float32,
+    )
+    times = np.array([0.0, 0.05, 0.15], dtype=np.float32)
+    freq_axis = np.array([100.0, 200.0], dtype=np.float32)
+
+    _, confidence = crepe_analysis.activation_to_frequency_confidence(
+        activation, times, freq_axis
+    )
+
+    expected_confidence = (0.9 * 0.05) + (0.7 * 0.1)
+    assert np.isclose(confidence, expected_confidence)


### PR DESCRIPTION
## Summary
- weight CREPE activation averaging by frame durations when computing the summary frequency and confidence
- update the activation summary label helper to pass frame times and frequency bins through to the calculation
- add tests covering duration-weighted confidence and fallback frequency handling when CREPE is unavailable

## Testing
- pytest tests/test_crepe_analysis.py *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_68d9e7c972ec8329bf02fdc3610236ff