### PR TITLE
Loop microphone capture in pitch comparison CLI

### DIFF
--- a/src/spectrum_analysis/compare_pitch_cli.py
+++ b/src/spectrum_analysis/compare_pitch_cli.py
@@ -882,7 +882,18 @@ def main(argv: Optional[Iterable[str]] = None) -> None:
                 )
             return
 
-    _run_comparison(cfg, output_dir)
+    if cfg.input_mode == "mic":
+        print(
+            "[INFO] Microphone mode active. Close the plot window to capture a new "
+            "sample or press Ctrl+C to exit."
+        )
+        try:
+            while True:
+                _run_comparison(cfg, output_dir)
+        except KeyboardInterrupt:
+            print("\n[INFO] Exiting microphone capture loop.")
+    else:
+        _run_comparison(cfg, output_dir)
 
 
 if __name__ == "__main__":  # pragma: no cover - CLI entry point


### PR DESCRIPTION
## Summary
- add a microphone-mode loop to repeat recordings whenever the plot window is closed
- provide user-facing messages for entering and exiting the microphone loop

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68daa636bb58832999971690a7b59305