### PR TITLE
Implement stationary noise spectrum subtraction

### DIFF
--- a/src/spectrum_analysis/audio_processing.py
+++ b/src/spectrum_analysis/audio_processing.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Optional, Tuple, TYPE_CHECKING
 
@@ -21,6 +22,16 @@ except Exception:  # pragma: no cover - dependency may be absent
 
 if TYPE_CHECKING:  # pragma: no cover - only for type checking
     from .compare_pitch_cli import PitchCompareConfig
+
+
+@dataclass(frozen=True)
+class NoiseProfile:
+    """Stationary noise statistics cached for spectral subtraction."""
+
+    freqs: np.ndarray
+    magnitude: np.ndarray
+    window_length: int
+    hop_length: int
 
 
 def load_audio(path: Path, target_sr: int) -> tuple[np.ndarray, int]:
@@ -108,13 +119,11 @@ def determine_window_and_hop(
     return window_samples, hop_samples
 
 
-def compute_noise_profile(
-    noise: np.ndarray, cfg: "PitchCompareConfig"
-) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
-    """Estimate the noise profile for spectral subtraction."""
+def compute_noise_profile(noise: np.ndarray, cfg: "PitchCompareConfig") -> NoiseProfile:
+    """Estimate the stationary noise spectrum for later subtraction."""
 
     win_len, hop_len = determine_window_and_hop(cfg, len(noise))
-    freqs, times, stft = signal.stft(
+    freqs, _, stft = signal.stft(
         noise,
         fs=cfg.sample_rate,
         window="hann",
@@ -122,8 +131,13 @@ def compute_noise_profile(
         noverlap=win_len - hop_len,
         padded=False,
     )
-    power = np.mean(np.abs(stft) ** 2, axis=1, keepdims=True)
-    return freqs, times, power
+    magnitude = np.mean(np.abs(stft), axis=1)
+    return NoiseProfile(
+        freqs=np.asarray(freqs, dtype=np.float32),
+        magnitude=np.asarray(magnitude, dtype=np.float32),
+        window_length=int(win_len),
+        hop_length=int(hop_len),
+    )
 
 
 def compute_spectrogram(
@@ -145,11 +159,12 @@ def compute_spectrogram(
 
 
 def subtract_noise(
-    audio: np.ndarray, noise_profile: np.ndarray, cfg: "PitchCompareConfig"
+    audio: np.ndarray, noise_profile: NoiseProfile, cfg: "PitchCompareConfig"
 ) -> tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
-    """Perform spectral subtraction to reduce noise in the signal."""
+    """Perform spectral subtraction using a stationary noise spectrum."""
 
-    win_len, hop_len = determine_window_and_hop(cfg, len(audio))
+    win_len = noise_profile.window_length
+    hop_len = noise_profile.hop_length
     freqs, times, stft = signal.stft(
         audio,
         fs=cfg.sample_rate,
@@ -158,11 +173,16 @@ def subtract_noise(
         noverlap=win_len - hop_len,
         padded=False,
     )
-    power = np.abs(stft) ** 2
-    adjusted_noise = noise_profile * cfg.over_subtraction
-    clean_power = np.maximum(power - adjusted_noise, 0.0)
-    magnitude = np.sqrt(clean_power)
-    cleaned_stft = magnitude * np.exp(1j * np.angle(stft))
+
+    if stft.shape[0] != noise_profile.magnitude.size:
+        raise ValueError(
+            "Noise profile frequency bins do not match the audio STFT dimensions."
+        )
+
+    magnitude = np.abs(stft)
+    noise_mag = noise_profile.magnitude.reshape(-1, 1) * float(cfg.over_subtraction)
+    cleaned_magnitude = np.maximum(magnitude - noise_mag, 0.0)
+    cleaned_stft = cleaned_magnitude * np.exp(1j * np.angle(stft))
     _, reconstructed = signal.istft(
         cleaned_stft,
         fs=cfg.sample_rate,
@@ -172,4 +192,5 @@ def subtract_noise(
         input_onesided=True,
     )
     reconstructed = np.asarray(reconstructed, dtype=np.float32)
+    clean_power = cleaned_magnitude**2
     return reconstructed, freqs, times, clean_power

--- a/src/spectrum_analysis/compare_pitch_cli.py
+++ b/src/spectrum_analysis/compare_pitch_cli.py
@@ -786,7 +786,7 @@ def _run_comparison(cfg: PitchCompareConfig, output_dir: Path) -> None:
     else:
         noise = record_noise_sample(cfg)
         noise_rms = float(np.sqrt(np.mean(np.square(noise)) + 1e-12))
-        _, _, noise_profile = compute_noise_profile(noise, cfg)
+        noise_profile = compute_noise_profile(noise, cfg)
         audio = acquire_audio(cfg, noise_rms)
         filtered_audio, freqs, times, power = subtract_noise(audio, noise_profile, cfg)
 


### PR DESCRIPTION
## Summary
- add a `NoiseProfile` data class that stores the stationary spectrum of the noise sample
- compute the cached noise spectrum once and reuse it when subtracting from recordings
- update the subtraction routine to operate on magnitude spectra with the cached window and hop sizes

## Testing
- pytest *(fails: missing optional dependencies matplotlib and pandas in test environment)*

------
https://chatgpt.com/codex/tasks/task_e_68daba16cc888329bbb7803e24d9a8d0