### PR TITLE
Refine stationary noise subtraction and add test

### DIFF
--- a/src/spectrum_analysis/compare_pitch_cli.py
+++ b/src/spectrum_analysis/compare_pitch_cli.py
@@ -32,6 +32,8 @@ from audio_processing import (
     compute_spectrogram,
     determine_window_and_hop,
     load_audio,
+    load_noise_profile,
+    save_noise_profile,
     subtract_noise,
 )
 from crepe_analysis import (
@@ -784,10 +786,27 @@ def _run_comparison(cfg: PitchCompareConfig, output_dir: Path) -> None:
         filtered_audio = audio
         freqs, times, power = compute_spectrogram(filtered_audio, cfg)
     else:
-        noise = record_noise_sample(cfg)
-        noise_rms = float(np.sqrt(np.mean(np.square(noise)) + 1e-12))
-        _, _, noise_profile = compute_noise_profile(noise, cfg)
-        audio = acquire_audio(cfg, noise_rms)
+        duration_samples = int(cfg.noise_duration * cfg.sample_rate)
+        win_len, hop_len = determine_window_and_hop(cfg, duration_samples)
+        cache_dir = Path(cfg.output_directory) / "noise_filters"
+        cache_name = (
+            f"stationary_noise_sr{cfg.sample_rate}_n{duration_samples}"
+            f"_win{win_len}_hop{hop_len}.npz"
+        )
+        cache_path = cache_dir / cache_name
+
+        noise_profile = load_noise_profile(
+            cache_path,
+            cfg,
+            expected_window=win_len,
+            expected_hop=hop_len,
+        )
+        if noise_profile is None:
+            noise = record_noise_sample(cfg)
+            noise_profile = compute_noise_profile(noise, cfg)
+            save_noise_profile(noise_profile, cache_path, cfg.sample_rate)
+
+        audio = acquire_audio(cfg, noise_profile.rms)
         filtered_audio, freqs, times, power = subtract_noise(audio, noise_profile, cfg)
 
         audio_path = save_audio(timestamp, filtered_audio, cfg, output_dir)

--- a/tests/test_noise_subtraction.py
+++ b/tests/test_noise_subtraction.py
@@ -1,0 +1,37 @@
+"""Tests for stationary noise subtraction utilities."""
+
+from __future__ import annotations
+
+import pytest
+
+np = pytest.importorskip("numpy")
+
+from src.spectrum_analysis.audio_processing import (
+    compute_noise_profile,
+    subtract_noise,
+)
+from src.spectrum_analysis.compare_pitch_cli import PitchCompareConfig
+
+
+def test_stationary_noise_subtraction_removes_noise() -> None:
+    """A stationary noise sample should subtract to nearly silence."""
+
+    cfg = PitchCompareConfig(
+        sample_rate=8000,
+        min_frequency=40.0,
+        min_oscillations_per_window=10.0,
+        min_window_overlap=0.5,
+        over_subtraction=1.0,
+    )
+
+    rng = np.random.default_rng(seed=1234)
+    duration = int(0.5 * cfg.sample_rate)
+    noise = rng.normal(scale=0.05, size=duration).astype(np.float32)
+
+    profile = compute_noise_profile(noise, cfg)
+    filtered, _, _, _ = subtract_noise(noise, profile, cfg)
+
+    residual_rms = float(np.sqrt(np.mean(filtered**2) + 1e-12))
+    original_rms = float(np.sqrt(np.mean(noise**2) + 1e-12))
+
+    assert residual_rms < original_rms * 0.05


### PR DESCRIPTION
## Summary
- average the stationary noise profile directly in the complex STFT domain and persist it in the cache
- update spectral subtraction to remove the cached complex spectrum frame by frame and compute power from the cleaned STFT
- add a regression test that verifies stationary noise subtracts to near-silence when NumPy is available

## Testing
- pytest tests/test_noise_subtraction.py *(skipped: NumPy not installed in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68daba16cc888329bbb7803e24d9a8d0