### PR TITLE
Implement harmonic comb trigger for audio capture

### DIFF
--- a/src/spectrum_analysis/compare_pitch_cli.py
+++ b/src/spectrum_analysis/compare_pitch_cli.py
@@ -6,6 +6,7 @@ import argparse
 import dataclasses
 import datetime as _dt
 import json
+from collections import deque
 from pathlib import Path
 from typing import Any, Dict, Iterable, List, Optional, Tuple
 
@@ -321,19 +322,11 @@ def record_noise_sample(cfg: PitchCompareConfig) -> np.ndarray:
     return np.squeeze(noise).astype(np.float32)
 
 
-def acquire_audio(cfg: PitchCompareConfig, noise_rms: float) -> np.ndarray:
-    if cfg.input_mode == "file":
-        if cfg.input_audio_path is None:
-            raise ValueError(
-                "input_audio_path must be provided when input_mode is 'file'"
-            )
-        audio, _ = load_audio(Path(cfg.input_audio_path), cfg.sample_rate)
-        return audio
-
+def _acquire_audio_snr(cfg: PitchCompareConfig, noise_rms: float) -> np.ndarray:
     _, hop = determine_window_and_hop(cfg)
     source = MicSource(cfg.sample_rate, hop)
     source.start()
-    print("[INFO] Listening for audio events...")
+    print("[INFO] Listening for audio events (RMS trigger)...")
     snr_threshold = 10 ** (cfg.snr_threshold_db / 20.0)
     collected: list[np.ndarray] = []
     above = False
@@ -374,6 +367,232 @@ def acquire_audio(cfg: PitchCompareConfig, noise_rms: float) -> np.ndarray:
 
     if not collected:
         raise RuntimeError("No audio captured above the SNR threshold.")
+
+    return np.concatenate(collected).astype(np.float32)
+
+
+def _spectral_flatness(magnitude: np.ndarray) -> float:
+    eps = 1e-12
+    magnitude = np.maximum(magnitude, eps)
+    geom_mean = np.exp(np.mean(np.log(magnitude)))
+    arith_mean = np.mean(magnitude)
+    return float(geom_mean / (arith_mean + eps))
+
+
+def _harmonic_comb_response(
+    frame: np.ndarray,
+    sample_rate: int,
+    window: np.ndarray,
+    freq_bins: np.ndarray,
+    candidates: np.ndarray,
+    weights: np.ndarray,
+    min_harmonics: int,
+) -> Tuple[float, float, bool]:
+    windowed = frame * window
+    spectrum = np.fft.rfft(windowed)
+    magnitude = np.abs(spectrum)
+    sfm = _spectral_flatness(magnitude)
+    magnitude_db = 20.0 * np.log10(np.maximum(magnitude, 1e-12))
+
+    max_mag = float(np.max(magnitude) + 1e-12)
+    nyquist = sample_rate / 2.0
+    bin_width = freq_bins[1] - freq_bins[0] if freq_bins.size > 1 else nyquist
+
+    best_r = 0.0
+    found = False
+
+    for candidate in candidates:
+        if not np.isfinite(candidate) or candidate <= 0.0:
+            continue
+
+        harmonics = candidate * np.arange(1, weights.size + 1, dtype=np.float64)
+        valid_mask = harmonics <= nyquist
+        if not np.any(valid_mask):
+            continue
+
+        harmonics = harmonics[valid_mask]
+        local_weights = weights[: harmonics.size]
+
+        sampled = np.interp(harmonics, freq_bins, magnitude, left=0.0, right=0.0)
+        if sampled.size < min_harmonics:
+            continue
+
+        amps_db = 20.0 * np.log10(np.maximum(sampled, 1e-12))
+        idx = np.clip(
+            np.round(harmonics / max(bin_width, 1e-12)).astype(int),
+            0,
+            magnitude_db.size - 1,
+        )
+        prominences = []
+        for bin_idx in idx:
+            lo = max(bin_idx - 3, 0)
+            hi = min(bin_idx + 3, magnitude_db.size - 1)
+            prominences.append(magnitude_db[lo : hi + 1])
+        if prominences:
+            floor_db = np.array([float(np.median(p)) for p in prominences])
+        else:
+            floor_db = np.zeros(0, dtype=np.float64)
+
+        if floor_db.size < sampled.size:
+            floor_db = np.pad(floor_db, (0, sampled.size - floor_db.size), mode="edge")
+
+        if np.count_nonzero(amps_db - floor_db >= 8.0) < min_harmonics:
+            continue
+
+        local_weight_sum = float(np.sum(local_weights))
+        weighted_sum = float(np.sum(local_weights * sampled))
+        if local_weight_sum > 0.0:
+            r_value = weighted_sum / (local_weight_sum * max_mag)
+        else:
+            r_value = 0.0
+
+        if r_value > best_r:
+            best_r = r_value
+            found = True
+
+    return best_r, sfm, found
+
+
+def acquire_audio(cfg: PitchCompareConfig, noise_rms: float) -> np.ndarray:
+    if cfg.input_mode == "file":
+        if cfg.input_audio_path is None:
+            raise ValueError(
+                "input_audio_path must be provided when input_mode is 'file'"
+            )
+        audio, _ = load_audio(Path(cfg.input_audio_path), cfg.sample_rate)
+        return audio
+
+    expected_f0 = cfg.expected_f0
+    if expected_f0 is None or not np.isfinite(expected_f0) or expected_f0 <= 0.0:
+        print("[WARN] expected_f0 missing; falling back to RMS trigger.")
+        return _acquire_audio_snr(cfg, noise_rms)
+
+    if sd is None:
+        raise RuntimeError(
+            "sounddevice is required for microphone recording but is not available."
+        )
+
+    frame_size = 2048
+    hop = 1024
+    window = np.hanning(frame_size).astype(np.float32)
+    freq_bins = np.fft.rfftfreq(frame_size, d=1.0 / cfg.sample_rate)
+    nyquist = cfg.sample_rate / 2.0
+
+    f_min = max(
+        expected_f0 / 2.0, freq_bins[1] if freq_bins.size > 1 else expected_f0 / 2.0
+    )
+    f_max = min(expected_f0 * 2.0, nyquist)
+    if not np.isfinite(f_min) or not np.isfinite(f_max) or f_max <= f_min:
+        print("[WARN] Invalid frequency band; falling back to RMS trigger.")
+        return _acquire_audio_snr(cfg, noise_rms)
+
+    candidates = np.geomspace(f_min, f_max, num=36)
+    weights = 1.0 / np.arange(1, 11, dtype=np.float64)
+    min_harmonics = 4
+
+    source = MicSource(cfg.sample_rate, hop)
+    source.start()
+    print("[INFO] Listening for audio events (harmonic comb trigger)...")
+
+    collected: list[np.ndarray] = []
+    max_samples = int(cfg.max_record_seconds * cfg.sample_rate)
+    collected_samples = 0
+
+    frame_buffer = np.zeros(0, dtype=np.float32)
+    recent_chunks: deque[np.ndarray] = deque()
+    recent_samples = 0
+
+    on_counter = 0
+    off_counter = 0
+    triggered = False
+
+    try:
+        while collected_samples < max_samples:
+            chunk = source.read()
+            if chunk.size == 0:
+                continue
+
+            if chunk.dtype != np.float32:
+                chunk = chunk.astype(np.float32, copy=False)
+
+            frame_buffer = np.concatenate((frame_buffer, chunk))
+
+            recent_chunks.append(chunk.copy())
+            recent_samples += len(chunk)
+            while recent_samples > frame_size:
+                removed = recent_chunks.popleft()
+                recent_samples -= len(removed)
+
+            was_triggered = triggered
+            chunk_included = False
+            stop_recording = False
+
+            while frame_buffer.size >= frame_size:
+                frame = frame_buffer[:frame_size]
+                r_value, sfm, valid = _harmonic_comb_response(
+                    frame,
+                    cfg.sample_rate,
+                    window,
+                    freq_bins,
+                    candidates,
+                    weights,
+                    min_harmonics,
+                )
+                frame_buffer = frame_buffer[hop:]
+
+                if not triggered:
+                    if valid and r_value > 0.25 and sfm < 0.6:
+                        on_counter += 1
+                    else:
+                        on_counter = 0
+
+                    if on_counter >= 3:
+                        triggered = True
+                        on_counter = 0
+                        off_counter = 0
+                        chunk_included = True
+                        pre_audio = (
+                            np.concatenate(list(recent_chunks))
+                            if recent_chunks
+                            else np.empty(0, dtype=np.float32)
+                        )
+                        if pre_audio.size:
+                            collected.append(pre_audio.astype(np.float32, copy=False))
+                            collected_samples += pre_audio.size
+                        recent_chunks.clear()
+                        recent_samples = 0
+                        print("[INFO] Recording started (harmonic comb trigger).")
+                        if collected_samples >= max_samples:
+                            stop_recording = True
+                            break
+                else:
+                    if r_value < 0.18:
+                        off_counter += 1
+                        if off_counter >= 2:
+                            triggered = False
+                            stop_recording = True
+                            print("[INFO] Recording stopped (comb trigger released).")
+                            break
+                    else:
+                        off_counter = 0
+
+            if was_triggered and not chunk_included:
+                collected.append(chunk.astype(np.float32, copy=False))
+                collected_samples += len(chunk)
+
+            if collected_samples >= max_samples:
+                print("[WARN] Max recording length reached.")
+                break
+
+            if stop_recording:
+                break
+        else:
+            print("[WARN] Max recording length reached.")
+    finally:
+        source.stop()
+
+    if not collected:
+        raise RuntimeError("No audio captured above the comb trigger thresholds.")
 
     return np.concatenate(collected).astype(np.float32)
 


### PR DESCRIPTION
## Summary
- add a harmonic-comb-based trigger path for microphone recordings in `compare_pitch_cli`
- compute candidate responses with spectral flatness and harmonic prominence checks before starting or stopping capture
- retain the prior RMS-trigger logic as a fallback when the comb trigger cannot operate

## Testing
- pytest *(fails: missing optional dependencies such as pandas and sounddevice-related modules)*

------
https://chatgpt.com/codex/tasks/task_e_68dc1f5d99588329be64c843ad496929