### PR TITLE
Refactor audio acquisition out of compare_pitch_cli

### DIFF
--- a/src/spectrum_analysis/audio_processing.py
+++ b/src/spectrum_analysis/audio_processing.py
@@ -2,9 +2,10 @@
 
 from __future__ import annotations
 
+from collections import deque
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Optional, TYPE_CHECKING
+from typing import TYPE_CHECKING, Optional
 
 import numpy as np
 from scipy import signal
@@ -19,6 +20,8 @@ try:  # Optional dependency - full audio analysis toolkit
     import librosa  # type: ignore
 except Exception:  # pragma: no cover - dependency may be absent
     librosa = None  # type: ignore
+
+from audio_sources import MicSource, sd
 
 if TYPE_CHECKING:  # pragma: no cover - only for type checking
     from .compare_pitch_cli import PitchCompareConfig
@@ -294,3 +297,321 @@ def subtract_noise(
     reconstructed = np.asarray(reconstructed, dtype=np.float32)
     clean_power = np.abs(cleaned_stft) ** 2
     return reconstructed, freqs, times, clean_power
+
+
+def record_noise_sample(cfg: "PitchCompareConfig") -> np.ndarray:
+    """Capture a noise sample for calibration or load it from disk."""
+
+    duration_samples = int(cfg.noise_duration * cfg.sample_rate)
+
+    if cfg.input_mode == "file" and cfg.noise_audio_path:
+        noise, _ = load_audio(Path(cfg.noise_audio_path), cfg.sample_rate)
+        if len(noise) > duration_samples:
+            return noise[:duration_samples]
+        if len(noise) < duration_samples:
+            pad = duration_samples - len(noise)
+            return np.pad(noise, (0, pad), mode="edge")
+        return noise
+
+    if cfg.input_mode == "file":
+        if cfg.input_audio_path is None:
+            raise ValueError(
+                "input_audio_path must be provided when input_mode is 'file'"
+            )
+        audio, _ = load_audio(Path(cfg.input_audio_path), cfg.sample_rate)
+        return audio[:duration_samples]
+
+    if sd is None:
+        raise RuntimeError(
+            "sounddevice is required for microphone recording but is not available."
+        )
+
+    print(f"[INFO] Recording {cfg.noise_duration:.1f}s of background noise...")
+    noise = sd.rec(
+        duration_samples, samplerate=cfg.sample_rate, channels=1, dtype="float32"
+    )
+    sd.wait()
+    return np.squeeze(noise).astype(np.float32)
+
+
+def _acquire_audio_snr(cfg: "PitchCompareConfig", noise_rms: float) -> np.ndarray:
+    _, hop = determine_window_and_hop(cfg)
+    source = MicSource(cfg.sample_rate, hop)
+    source.start()
+    print("[INFO] Listening for audio events (RMS trigger)...")
+    snr_threshold = 10 ** (cfg.snr_threshold_db / 20.0)
+    collected: list[np.ndarray] = []
+    above = False
+    recording_started = False
+    idle_samples = 0
+    idle_limit = int(cfg.idle_timeout * cfg.sample_rate)
+    max_samples = int(cfg.max_record_seconds * cfg.sample_rate)
+    collected_samples = 0
+
+    try:
+        while collected_samples < max_samples:
+            chunk = source.read()
+            if chunk.size == 0:
+                continue
+
+            chunk_rms = np.sqrt(np.mean(np.square(chunk)) + 1e-12)
+            ratio = chunk_rms / (noise_rms + 1e-12)
+
+            if ratio >= snr_threshold:
+                if not recording_started:
+                    print("[INFO] Recording started.")
+                    recording_started = True
+                above = True
+                idle_samples = 0
+                collected.append(chunk)
+                collected_samples += len(chunk)
+            elif above:
+                idle_samples += len(chunk)
+                collected.append(chunk)
+                collected_samples += len(chunk)
+                if idle_samples >= idle_limit:
+                    print("[INFO] Recording stopped (signal below threshold).")
+                    break
+        else:
+            print("[WARN] Max recording length reached.")
+    finally:
+        source.stop()
+
+    if not collected:
+        raise RuntimeError("No audio captured above the SNR threshold.")
+
+    return np.concatenate(collected).astype(np.float32)
+
+
+def _spectral_flatness(magnitude: np.ndarray) -> float:
+    eps = 1e-12
+    magnitude = np.maximum(magnitude, eps)
+    geom_mean = np.exp(np.mean(np.log(magnitude)))
+    arith_mean = np.mean(magnitude)
+    return float(geom_mean / (arith_mean + eps))
+
+
+def _harmonic_comb_response(
+    frame: np.ndarray,
+    sample_rate: int,
+    window: np.ndarray,
+    freq_bins: np.ndarray,
+    candidates: np.ndarray,
+    weights: np.ndarray,
+    min_harmonics: int,
+) -> tuple[float, float, bool]:
+    windowed = frame * window
+    spectrum = np.fft.rfft(windowed)
+    magnitude = np.abs(spectrum)
+    sfm = _spectral_flatness(magnitude)
+    magnitude_db = 20.0 * np.log10(np.maximum(magnitude, 1e-12))
+
+    max_mag = float(np.max(magnitude) + 1e-12)
+    nyquist = sample_rate / 2.0
+    bin_width = freq_bins[1] - freq_bins[0] if freq_bins.size > 1 else nyquist
+
+    best_r = 0.0
+    found = False
+
+    for candidate in candidates:
+        if not np.isfinite(candidate) or candidate <= 0.0:
+            continue
+
+        harmonics = candidate * np.arange(1, weights.size + 1, dtype=np.float64)
+        valid_mask = harmonics <= nyquist
+        if not np.any(valid_mask):
+            continue
+
+        harmonics = harmonics[valid_mask]
+        local_weights = weights[: harmonics.size]
+
+        sampled = np.interp(harmonics, freq_bins, magnitude, left=0.0, right=0.0)
+        if sampled.size < min_harmonics:
+            continue
+
+        amps_db = 20.0 * np.log10(np.maximum(sampled, 1e-12))
+        idx = np.clip(
+            np.round(harmonics / max(bin_width, 1e-12)).astype(int),
+            0,
+            magnitude_db.size - 1,
+        )
+        prominences = []
+        for bin_idx in idx:
+            lo = max(bin_idx - 3, 0)
+            hi = min(bin_idx + 3, magnitude_db.size - 1)
+            prominences.append(magnitude_db[lo : hi + 1])
+        if prominences:
+            floor_db = np.array([float(np.median(p)) for p in prominences])
+        else:
+            floor_db = np.zeros(0, dtype=np.float64)
+
+        if floor_db.size < sampled.size:
+            floor_db = np.pad(floor_db, (0, sampled.size - floor_db.size), mode="edge")
+
+        if np.count_nonzero(amps_db - floor_db >= 8.0) < min_harmonics:
+            continue
+
+        local_weight_sum = float(np.sum(local_weights))
+        weighted_sum = float(np.sum(local_weights * sampled))
+        if local_weight_sum > 0.0:
+            r_value = weighted_sum / (local_weight_sum * max_mag)
+        else:
+            r_value = 0.0
+
+        if r_value > best_r:
+            best_r = r_value
+            found = True
+
+    return best_r, sfm, found
+
+
+def acquire_audio(cfg: "PitchCompareConfig", noise_rms: float) -> np.ndarray:
+    """Record audio using harmonic-comb triggering or load from file."""
+
+    if cfg.input_mode == "file":
+        if cfg.input_audio_path is None:
+            raise ValueError(
+                "input_audio_path must be provided when input_mode is 'file'"
+            )
+        audio, _ = load_audio(Path(cfg.input_audio_path), cfg.sample_rate)
+        return audio
+
+    expected_f0 = cfg.expected_f0
+    if expected_f0 is None or not np.isfinite(expected_f0) or expected_f0 <= 0.0:
+        print("[WARN] expected_f0 missing; falling back to RMS trigger.")
+        return _acquire_audio_snr(cfg, noise_rms)
+
+    if sd is None:
+        raise RuntimeError(
+            "sounddevice is required for microphone recording but is not available."
+        )
+
+    frame_size = 2048
+    hop = 1024
+    window = np.hanning(frame_size).astype(np.float32)
+    freq_bins = np.fft.rfftfreq(frame_size, d=1.0 / cfg.sample_rate)
+    nyquist = cfg.sample_rate / 2.0
+
+    f_min = max(
+        expected_f0 / 2.0, freq_bins[1] if freq_bins.size > 1 else expected_f0 / 2.0
+    )
+    f_max = min(expected_f0 * 2.0, nyquist)
+    if not np.isfinite(f_min) or not np.isfinite(f_max) or f_max <= f_min:
+        print("[WARN] Invalid frequency band; falling back to RMS trigger.")
+        return _acquire_audio_snr(cfg, noise_rms)
+
+    candidates = np.geomspace(f_min, f_max, num=36)
+    weights = 1.0 / np.arange(1, 11, dtype=np.float64)
+    min_harmonics = max(1, int(cfg.comb_trigger_min_harmonics))
+    on_frames = max(1, int(cfg.comb_trigger_on_frames))
+    off_frames = max(1, int(cfg.comb_trigger_off_frames))
+
+    source = MicSource(cfg.sample_rate, hop)
+    source.start()
+    print("[INFO] Listening for audio events (harmonic comb trigger)...")
+
+    collected: list[np.ndarray] = []
+    max_samples = int(cfg.max_record_seconds * cfg.sample_rate)
+    collected_samples = 0
+
+    frame_buffer = np.zeros(0, dtype=np.float32)
+    recent_chunks: deque[np.ndarray] = deque()
+    recent_samples = 0
+
+    on_counter = 0
+    off_counter = 0
+    triggered = False
+
+    try:
+        while collected_samples < max_samples:
+            chunk = source.read()
+            if chunk.size == 0:
+                continue
+
+            if chunk.dtype != np.float32:
+                chunk = chunk.astype(np.float32, copy=False)
+
+            frame_buffer = np.concatenate((frame_buffer, chunk))
+
+            recent_chunks.append(chunk.copy())
+            recent_samples += len(chunk)
+            while recent_samples > frame_size:
+                removed = recent_chunks.popleft()
+                recent_samples -= len(removed)
+
+            was_triggered = triggered
+            chunk_included = False
+            stop_recording = False
+
+            while frame_buffer.size >= frame_size:
+                frame = frame_buffer[:frame_size]
+                r_value, sfm, valid = _harmonic_comb_response(
+                    frame,
+                    cfg.sample_rate,
+                    window,
+                    freq_bins,
+                    candidates,
+                    weights,
+                    min_harmonics,
+                )
+                frame_buffer = frame_buffer[hop:]
+
+                if not triggered:
+                    if (
+                        valid
+                        and r_value > cfg.comb_trigger_on_rmax
+                        and sfm < cfg.comb_trigger_sfm_max
+                    ):
+                        on_counter += 1
+                    else:
+                        on_counter = 0
+
+                    if on_counter >= on_frames:
+                        triggered = True
+                        on_counter = 0
+                        off_counter = 0
+                        chunk_included = True
+                        pre_audio = (
+                            np.concatenate(list(recent_chunks))
+                            if recent_chunks
+                            else np.empty(0, dtype=np.float32)
+                        )
+                        if pre_audio.size:
+                            collected.append(pre_audio.astype(np.float32, copy=False))
+                            collected_samples += pre_audio.size
+                        recent_chunks.clear()
+                        recent_samples = 0
+                        print("[INFO] Recording started (harmonic comb trigger).")
+                        if collected_samples >= max_samples:
+                            stop_recording = True
+                            break
+                else:
+                    if r_value < cfg.comb_trigger_off_rmax:
+                        off_counter += 1
+                        if off_counter >= off_frames:
+                            triggered = False
+                            stop_recording = True
+                            print("[INFO] Recording stopped (comb trigger released).")
+                            break
+                    else:
+                        off_counter = 0
+
+            if was_triggered and not chunk_included:
+                collected.append(chunk.astype(np.float32, copy=False))
+                collected_samples += len(chunk)
+
+            if collected_samples >= max_samples:
+                print("[WARN] Max recording length reached.")
+                break
+
+            if stop_recording:
+                break
+        else:
+            print("[WARN] Max recording length reached.")
+    finally:
+        source.stop()
+
+    if not collected:
+        raise RuntimeError("No audio captured above the comb trigger thresholds.")
+
+    return np.concatenate(collected).astype(np.float32)


### PR DESCRIPTION
## Summary
- move noise recording, RMS trigger, and harmonic-comb capture helpers into `audio_processing`
- update the CLI to import the shared helpers so it now focuses on orchestration and plotting

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dc1f5d99588329be64c843ad496929