### PR TITLE
Switch spectrogram scroller to harmonic comb trigger

### DIFF
--- a/src/spectrum_analysis/spectrogram_scroller_basic_config.json
+++ b/src/spectrum_analysis/spectrogram_scroller_basic_config.json
@@ -10,8 +10,6 @@
   "over_sub": 1.0,
   "min_freq": 10.0,
   "ac_win_sec": 0.5,
-  "snr_trigger": 0,
-  "snr_release": 0,
   "pre_record_sec": 0.5,
   "post_record_sec": 0.5,
   "expected_f0": 70.0


### PR DESCRIPTION
## Summary
- enable the scrolling spectrogram to reuse the harmonic comb trigger logic and fall back to SNR only when no expected f0 is provided
- add comb trigger configuration fields and state management to `SpectrogramConfig`
- seed the default scroller configuration with an `expected_f0` value so the harmonic comb trigger activates out of the box

## Testing
- No automated tests were run (project lacks a prescribed test suite)


------
https://chatgpt.com/codex/tasks/task_e_68dc85a22de0832992785db019a9a2a3