### PR TITLE
Convert relative imports to absolute paths in GUI and spectrum modules

### DIFF
--- a/src/dune_tension/gui/__init__.py
+++ b/src/dune_tension/gui/__init__.py
@@ -1,8 +1,8 @@
 """GUI helpers for the DUNE tensiometer application."""
 
-from .app import run_app
-from .context import GUIContext, GUIWidgets, create_context
-from .state import load_state, save_state
+from dune_tension.gui.app import run_app
+from dune_tension.gui.context import GUIContext, GUIWidgets, create_context
+from dune_tension.gui.state import load_state, save_state
 
 __all__ = [
     "GUIContext",

--- a/src/dune_tension/gui/app.py
+++ b/src/dune_tension/gui/app.py
@@ -6,7 +6,7 @@ from functools import partial
 from typing import Any
 import tkinter as tk
 
-from .actions import (
+from dune_tension.gui.actions import (
     calibrate_background_noise,
     clear_outliers,
     clear_range,
@@ -22,8 +22,8 @@ from .actions import (
     set_manual_tension,
     update_focus_command_indicator,
 )
-from .context import GUIContext, GUIWidgets, create_context
-from .state import load_state
+from dune_tension.gui.context import GUIContext, GUIWidgets, create_context
+from dune_tension.gui.state import load_state
 
 
 def run_app(state_file: str = "gui_state.json", root: tk.Misc | None = None) -> None:
@@ -62,9 +62,7 @@ def _initialise_servo(ctx: GUIContext) -> None:
         value = int(ctx.widgets.focus_slider.get())
     except Exception:
         value = 4000
-    ctx.servo_controller.on_focus_command = partial(
-        update_focus_command_indicator, ctx
-    )
+    ctx.servo_controller.on_focus_command = partial(update_focus_command_indicator, ctx)
     ctx.servo_controller.focus_position = value
     try:
         ctx.servo_controller.focus_target(value)
@@ -77,7 +75,11 @@ def _initialise_servo(ctx: GUIContext) -> None:
 def _create_widgets(
     root: tk.Misc, focus_command_var: tk.StringVar
 ) -> tuple[
-    GUIWidgets, tk.Canvas | None, Any | None, dict[str, tk.Button], list[tuple[tk.Button, int, int]]
+    GUIWidgets,
+    tk.Canvas | None,
+    Any | None,
+    dict[str, tk.Button],
+    list[tuple[tk.Button, int, int]],
 ]:
     """Build and layout the GUI widgets."""
 
@@ -117,7 +119,9 @@ def _create_widgets(
         row=3, column=1, sticky="w"
     )
 
-    tk.Label(measure_frame, text="Samples per Wire (≥1):").grid(row=0, column=0, sticky="e")
+    tk.Label(measure_frame, text="Samples per Wire (≥1):").grid(
+        row=0, column=0, sticky="e"
+    )
     entry_samples = tk.Entry(measure_frame)
     entry_samples.grid(row=0, column=1)
 
@@ -127,7 +131,9 @@ def _create_widgets(
     entry_confidence = tk.Entry(measure_frame)
     entry_confidence.grid(row=1, column=1)
 
-    tk.Label(measure_frame, text="Record Duration (s):").grid(row=9, column=0, sticky="e")
+    tk.Label(measure_frame, text="Record Duration (s):").grid(
+        row=9, column=0, sticky="e"
+    )
     entry_record_duration = tk.Entry(measure_frame)
     entry_record_duration.grid(row=9, column=1)
 
@@ -195,7 +201,9 @@ def _create_widgets(
     accel_slider.set(1)
     accel_slider.grid(row=1, column=1, sticky="ew")
 
-    tk.Label(servo_frame, text="Dwell Time (0.00–2.00s):").grid(row=2, column=0, sticky="e")
+    tk.Label(servo_frame, text="Dwell Time (0.00–2.00s):").grid(
+        row=2, column=0, sticky="e"
+    )
     dwell_slider = tk.Scale(servo_frame, from_=0, to=200, orient=tk.HORIZONTAL)
     dwell_slider.set(100)
     dwell_slider.grid(row=2, column=1, sticky="ew")
@@ -305,8 +313,12 @@ def _configure_commands(
         button.configure(command=partial(manual_increment, ctx, dx, dy))
 
     widgets = ctx.widgets
-    widgets.speed_slider.configure(command=lambda val: ctx.servo_controller.set_speed(int(float(val))))
-    widgets.accel_slider.configure(command=lambda val: ctx.servo_controller.set_accel(int(float(val))))
+    widgets.speed_slider.configure(
+        command=lambda val: ctx.servo_controller.set_speed(int(float(val)))
+    )
+    widgets.accel_slider.configure(
+        command=lambda val: ctx.servo_controller.set_accel(int(float(val)))
+    )
     widgets.dwell_slider.configure(
         command=lambda val: ctx.servo_controller.set_dwell_time(float(val) / 100)
     )

--- a/src/dune_tension/gui/context.py
+++ b/src/dune_tension/gui/context.py
@@ -8,10 +8,10 @@ from typing import Any, Callable
 import os
 import tkinter as tk
 
-from ..maestro import Controller, DummyController, ServoController
+from dune_tension.maestro import Controller, DummyController, ServoController
 
 try:  # pragma: no cover - optional dependency
-    from ..plc_io import (  # type: ignore
+    from dune_tension.plc_io import (  # type: ignore
         get_xy as plc_get_xy,
         goto_xy as plc_goto_xy,
         spoof_get_xy,

--- a/src/dune_tension/gui/state.py
+++ b/src/dune_tension/gui/state.py
@@ -7,7 +7,7 @@ import json
 import tkinter as tk
 from typing import Any
 
-from .context import GUIContext
+from dune_tension.gui.context import GUIContext
 
 
 @dataclass(slots=True)

--- a/src/dune_tension/main.py
+++ b/src/dune_tension/main.py
@@ -2,7 +2,13 @@
 
 from __future__ import annotations
 
-from .gui import run_app
+import sys
+from pathlib import Path
+
+if __package__ is None or __package__ == "":  # pragma: no cover - script execution shim
+    sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from dune_tension.gui import run_app
 
 
 def main() -> None:

--- a/src/spectrum_analysis/__init__.py
+++ b/src/spectrum_analysis/__init__.py
@@ -1,12 +1,12 @@
 """Spectrum analysis utilities and interactive visualizer."""
 
-from .audio_sources import AudioSource, DemoSource, MicSource
-from .cli import build_config, create_source, main, parse_args
-from .compare_pitch_cli import main as compare_pitch_main
-from .crepe_analysis import estimate_pitch_from_audio
-from .utils import EPS, dbfs, hann_window
-from .visualizer import ScrollingSpectrogram, SpectrogramConfig
-from .workflow import listen_for_trigger_and_classify
+from spectrum_analysis.audio_sources import AudioSource, DemoSource, MicSource
+from spectrum_analysis.cli import build_config, create_source, main, parse_args
+from spectrum_analysis.compare_pitch_cli import main as compare_pitch_main
+from spectrum_analysis.crepe_analysis import estimate_pitch_from_audio
+from spectrum_analysis.utils import EPS, dbfs, hann_window
+from spectrum_analysis.visualizer import ScrollingSpectrogram, SpectrogramConfig
+from spectrum_analysis.workflow import listen_for_trigger_and_classify
 
 __all__ = [
     "AudioSource",

--- a/src/spectrum_analysis/audio_processing.py
+++ b/src/spectrum_analysis/audio_processing.py
@@ -21,12 +21,12 @@ try:  # Optional dependency - full audio analysis toolkit
 except Exception:  # pragma: no cover - dependency may be absent
     librosa = None  # type: ignore
 
-from audio_sources import MicSource, sd
+from spectrum_analysis.audio_sources import MicSource, sd
 
-from comb_trigger import record_with_harmonic_comb
+from spectrum_analysis.comb_trigger import record_with_harmonic_comb
 
 if TYPE_CHECKING:  # pragma: no cover - only for type checking
-    from .pitch_compare_config import PitchCompareConfig
+    from spectrum_analysis.pitch_compare_config import PitchCompareConfig
 
 
 @dataclass(frozen=True)

--- a/src/spectrum_analysis/workflow.py
+++ b/src/spectrum_analysis/workflow.py
@@ -7,14 +7,17 @@ from typing import Optional, Tuple
 
 import numpy as np
 
-from .audio_processing import (
+from spectrum_analysis.audio_processing import (
     acquire_audio,
     compute_noise_profile,
     record_noise_sample,
     subtract_noise,
 )
-from .crepe_analysis import crepe_activations_to_pitch, get_crepe_activations
-from .pitch_compare_config import PitchCompareConfig
+from spectrum_analysis.crepe_analysis import (
+    crepe_activations_to_pitch,
+    get_crepe_activations,
+)
+from spectrum_analysis.pitch_compare_config import PitchCompareConfig
 
 
 PitchEstimationResult = Tuple[


### PR DESCRIPTION
## Summary
- replace intra-package relative imports in the dune_tension GUI with absolute imports to match the project convention
- swap spectrum_analysis relative imports for absolute package paths so the utilities can be imported consistently
- add a script-execution shim in dune_tension.main so absolute imports resolve when the entry point is run directly

## Testing
- ruff format .
- ruff check --fix . *(fails due to pre-existing lint in unrelated modules)*

------
https://chatgpt.com/codex/tasks/task_e_68dd552f285c83299225edfd30513785