### PR TITLE
Add type annotations and absolute imports

### DIFF
--- a/src/dune_tension/analyze.py
+++ b/src/dune_tension/analyze.py
@@ -7,10 +7,10 @@ import numpy as np
 import pandas as pd
 import seaborn as sns
 
-from data_cache import get_samples_dataframe
-from results import TensionResult
-from tensiometer_functions import TensiometerConfig
-from tension_calculation import calculate_kde_max, has_cluster
+from dune_tension.data_cache import get_samples_dataframe
+from dune_tension.results import TensionResult
+from dune_tension.tensiometer_functions import TensiometerConfig
+from dune_tension.tension_calculation import calculate_kde_max, has_cluster
 
 
 def get_expected_range(layer: str) -> range:

--- a/src/dune_tension/data_cache.py
+++ b/src/dune_tension/data_cache.py
@@ -1,7 +1,11 @@
-import pandas as pd
+from __future__ import annotations
+
 import sqlite3
 from pathlib import Path
-from results import EXPECTED_COLUMNS, RAW_SAMPLE_COLUMNS
+
+import pandas as pd
+
+from dune_tension.results import EXPECTED_COLUMNS, RAW_SAMPLE_COLUMNS
 
 # Global cache
 _dataframe_cache: dict[str, pd.DataFrame] = {}
@@ -127,7 +131,9 @@ def clear_outliers(
     subset = subset.sort_values("wire_number")
 
     # 8-wire centered moving average (require full window -> edges will be NaN)
-    rolling_mean = subset["tension"].rolling(window=8, center=True, min_periods=8).mean()
+    rolling_mean = (
+        subset["tension"].rolling(window=8, center=True, min_periods=8).mean()
+    )
 
     # Residuals from the rolling mean
     residuals = subset["tension"] - rolling_mean

--- a/src/dune_tension/geometry.py
+++ b/src/dune_tension/geometry.py
@@ -1,15 +1,17 @@
 # functions related to the geometry of the APA
 # geometry constants
-X_MIN = 1058
-X_MAX = 7011
-Y_MIN = 181
-Y_MAX = 2460
+from __future__ import annotations
+
+X_MIN: int = 1058
+X_MAX: int = 7011
+Y_MIN: int = 181
+Y_MAX: int = 2460
 
 
-G_LENGTH = 1.285
-X_LENGTH = 1.273
+G_LENGTH: float = 1.285
+X_LENGTH: float = 1.273
 
-comb_positions = [
+comb_positions: list[int] = [
     X_MIN,
     2230,
     3420,
@@ -17,10 +19,10 @@ comb_positions = [
     5770,
     X_MAX,
 ]
-COMB_SPACING = (X_MIN - X_MAX) / 5
+COMB_SPACING: float = (X_MIN - X_MAX) / 5
 
 
-def zone_lookup(x) -> int:
+def zone_lookup(x: float) -> int:
     """
     Determine the zone based on the x-coordinate.
     """
@@ -44,18 +46,18 @@ def refine_position(
     returned unchanged.
     """
 
-    def is_in_bounds(x: float, y: float) -> bool:
-        return X_MIN <= x <= X_MAX and Y_MIN <= y <= Y_MAX
+    def is_in_bounds(x_val: float, y_val: float) -> bool:
+        return X_MIN <= x_val <= X_MAX and Y_MIN <= y_val <= Y_MAX
 
     def score(pos: tuple[float, float]) -> float:
         """Return the minimal distance of ``pos`` to any limiting line."""
         px, py = pos
-        distances = [abs(px - c) for c in comb_positions]
+        distances: list[float] = [abs(px - c) for c in comb_positions]
         distances.append(abs(py - Y_MAX))
         distances.append(abs(py - Y_MIN))
         return min(distances)
 
-    candidates = []
+    candidates: list[tuple[float, float]] = []
 
     for n in range(300):
         # Generate forward and reverse candidates
@@ -69,7 +71,7 @@ def refine_position(
     if not candidates:
         return (x, y)
 
-    low_candidates = [
+    low_candidates: list[tuple[float, float]] = [
         c
         for c in candidates
         if c[1] < Y_MAX / 2 and score(c) > COMB_SPACING / 2 * 5.75 / 8
@@ -79,7 +81,9 @@ def refine_position(
     return max(candidates, key=score)
 
 
-def length_lookup(layer: str, wire_number: int, zone: int, taped=False):
+def length_lookup(
+    layer: str, wire_number: int, zone: int, taped: bool = False
+) -> float:
     import pandas as pd
 
     file_path = f"wire_lengths/{layer}_LUT.csv"
@@ -103,7 +107,7 @@ def length_lookup(layer: str, wire_number: int, zone: int, taped=False):
         raise ValueError("Zone must be between 1 and 5")
 
     try:
-        value = spreadsheet.at[wire_number, str(zone)]
+        value: float = float(spreadsheet.at[wire_number, str(zone)])
         if taped:
             return (value - 16) / 1000
         return value / 1000

--- a/src/spectrum_analysis/cli.py
+++ b/src/spectrum_analysis/cli.py
@@ -7,10 +7,10 @@ import json
 from pathlib import Path
 from typing import Any
 
-from audio_sources import DemoSource, MicSource, sd
-from visualizer import ScrollingSpectrogram, SpectrogramConfig
+from spectrum_analysis.audio_sources import AudioSource, DemoSource, MicSource, sd
+from spectrum_analysis.visualizer import ScrollingSpectrogram, SpectrogramConfig
 
-_SCROLLER_CONFIG_NAME = "spectrogram_scroller_basic_config.json"
+_SCROLLER_CONFIG_NAME: str = "spectrogram_scroller_basic_config.json"
 
 
 def load_scroller_config() -> dict[str, Any]:
@@ -78,7 +78,7 @@ def build_config(args: argparse.Namespace) -> SpectrogramConfig:
     return SpectrogramConfig(**config_kwargs)
 
 
-def create_source(args: argparse.Namespace):
+def create_source(args: argparse.Namespace) -> AudioSource:
     if args.demo or sd is None:
         return DemoSource(args.samplerate, args.hop)
     try:


### PR DESCRIPTION
## Summary
- add explicit type annotations for geometry constants and helpers
- switch dune_tension analysis modules to use absolute package imports
- annotate the spectrogram CLI configuration and audio source factory

## Testing
- ruff format src tests main.py
- ruff check --fix *(fails due to pre-existing lint errors outside the touched files)*

------
https://chatgpt.com/codex/tasks/task_e_68dd66bab37c8329a71ce6d4b85cf320