### PR TITLE
Fix circular imports in spectrum analysis package

### DIFF
--- a/src/spectrum_analysis/__init__.py
+++ b/src/spectrum_analysis/__init__.py
@@ -1,12 +1,9 @@
 """Spectrum analysis utilities and interactive visualizer."""
 
-from spectrum_analysis.audio_sources import AudioSource, DemoSource, MicSource
-from spectrum_analysis.cli import build_config, create_source, main, parse_args
-from spectrum_analysis.compare_pitch_cli import main as compare_pitch_main
-from spectrum_analysis.crepe_analysis import estimate_pitch_from_audio
-from spectrum_analysis.utils import EPS, dbfs, hann_window
-from spectrum_analysis.visualizer import ScrollingSpectrogram, SpectrogramConfig
-from spectrum_analysis.workflow import listen_for_trigger_and_classify
+from __future__ import annotations
+
+from importlib import import_module
+from typing import TYPE_CHECKING, Any
 
 __all__ = [
     "AudioSource",
@@ -25,3 +22,62 @@ __all__ = [
     "estimate_pitch_from_audio",
     "listen_for_trigger_and_classify",
 ]
+
+_EXPORT_MAP = {
+    "AudioSource": ("spectrum_analysis.audio_sources", "AudioSource"),
+    "DemoSource": ("spectrum_analysis.audio_sources", "DemoSource"),
+    "MicSource": ("spectrum_analysis.audio_sources", "MicSource"),
+    "ScrollingSpectrogram": (
+        "spectrum_analysis.visualizer",
+        "ScrollingSpectrogram",
+    ),
+    "SpectrogramConfig": (
+        "spectrum_analysis.visualizer",
+        "SpectrogramConfig",
+    ),
+    "EPS": ("spectrum_analysis.utils", "EPS"),
+    "dbfs": ("spectrum_analysis.utils", "dbfs"),
+    "hann_window": ("spectrum_analysis.utils", "hann_window"),
+    "parse_args": ("spectrum_analysis.cli", "parse_args"),
+    "build_config": ("spectrum_analysis.cli", "build_config"),
+    "create_source": ("spectrum_analysis.cli", "create_source"),
+    "main": ("spectrum_analysis.cli", "main"),
+    "compare_pitch_main": (
+        "spectrum_analysis.compare_pitch_cli",
+        "main",
+    ),
+    "estimate_pitch_from_audio": (
+        "spectrum_analysis.crepe_analysis",
+        "estimate_pitch_from_audio",
+    ),
+    "listen_for_trigger_and_classify": (
+        "spectrum_analysis.workflow",
+        "listen_for_trigger_and_classify",
+    ),
+}
+
+
+if TYPE_CHECKING:  # pragma: no cover - only for type checkers
+    from spectrum_analysis.audio_sources import AudioSource, DemoSource, MicSource
+    from spectrum_analysis.cli import build_config, create_source, main, parse_args
+    from spectrum_analysis.compare_pitch_cli import main as compare_pitch_main
+    from spectrum_analysis.crepe_analysis import estimate_pitch_from_audio
+    from spectrum_analysis.utils import EPS, dbfs, hann_window
+    from spectrum_analysis.visualizer import ScrollingSpectrogram, SpectrogramConfig
+    from spectrum_analysis.workflow import listen_for_trigger_and_classify
+
+
+def __getattr__(name: str) -> Any:
+    """Lazily import heavy submodules on demand."""
+
+    if name in _EXPORT_MAP:
+        module_name, attribute = _EXPORT_MAP[name]
+        module = import_module(module_name)
+        value = getattr(module, attribute)
+        globals()[name] = value
+        return value
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+
+def __dir__() -> list[str]:
+    return sorted(set(__all__))

--- a/src/spectrum_analysis/compare_pitch_cli.py
+++ b/src/spectrum_analysis/compare_pitch_cli.py
@@ -6,7 +6,7 @@ import argparse
 import dataclasses
 import datetime as _dt
 from pathlib import Path
-from typing import Iterable, List, Optional, Tuple
+from typing import Any, Iterable, List, Optional, Tuple
 
 import matplotlib.pyplot as plt
 from matplotlib.axes import Axes
@@ -24,7 +24,7 @@ try:  # Optional dependency - imported lazily when available
 except Exception:  # pragma: no cover - dependency may be absent
     pesto = None  # type: ignore
 
-from audio_processing import (
+from spectrum_analysis.audio_processing import (
     acquire_audio,
     compute_noise_profile,
     compute_spectrogram,
@@ -34,12 +34,16 @@ from audio_processing import (
     save_noise_profile,
     subtract_noise,
 )
-from crepe_analysis import (
+from spectrum_analysis.crepe_analysis import (
     crepe_activations_to_pitch,
     activation_map_to_pitch_track,
     get_crepe_activations,
 )
-from pitch_compare_config import PitchCompareConfig, ensure_output_dir, load_config
+from spectrum_analysis.pitch_compare_config import (
+    PitchCompareConfig,
+    ensure_output_dir,
+    load_config,
+)
 
 CREPE_FRAME_TARGET_RMS = 1
 CREPE_IDEAL_PITCH = 600.0  # Hz

--- a/src/spectrum_analysis/visualizer.py
+++ b/src/spectrum_analysis/visualizer.py
@@ -9,15 +9,15 @@ from typing import Optional
 import matplotlib.pyplot as plt
 import numpy as np
 
-from audio_sources import AudioSource
-from utils import dbfs, hann_window
+from spectrum_analysis.audio_sources import AudioSource
+from spectrum_analysis.utils import dbfs, hann_window
 
-from audio_processing import (
+from spectrum_analysis.audio_processing import (
     NoiseProfile,
     apply_noise_filter,
     compute_noise_profile,
 )
-from pitch_compare_config import PitchCompareConfig
+from spectrum_analysis.pitch_compare_config import PitchCompareConfig
 
 
 @dataclass
@@ -508,7 +508,6 @@ class ScrollingSpectrogram:
         if power <= 1e-12:
             self.acf_vals[:] = 0.0
             peak_freq = float("nan")
-            p2p = float("nan")
         else:
             acf_full = np.correlate(x, x, mode="full")
             acf_pos = acf_full[len(x) - 1 :]
@@ -531,20 +530,11 @@ class ScrollingSpectrogram:
             if peaks.size == 0:
                 gi = int(np.argmax(self.acf_vals[:L]))
                 peak_freq = float(self.acf_freq_axis_hz[gi])
-                p2p = float("nan")
             else:
                 prominences = self._compute_prominence(self.acf_vals[:L], peaks)
                 order = np.argsort(prominences)[::-1]
                 gi = int(peaks[order[0]])
                 peak_freq = float(self.acf_freq_axis_hz[gi])
-                if peaks.size >= 2:
-                    p1 = int(peaks[order[0]])
-                    p2 = int(peaks[order[1]])
-                    p2p = abs(
-                        float(self.acf_freq_axis_hz[p1] - self.acf_freq_axis_hz[p2])
-                    )
-                else:
-                    p2p = float("nan")
 
         if self.acf_freq_axis_hz.size > 0 and np.any(np.isfinite(self.acf_vals)):
             mask_finite = np.isfinite(self.acf_vals)


### PR DESCRIPTION
## Summary
- lazily load heavy exports in `spectrum_analysis.__init__` to avoid circular imports
- switch the CLI and visualizer modules to use absolute package imports

## Testing
- `ruff format src/spectrum_analysis/__init__.py src/spectrum_analysis/visualizer.py src/spectrum_analysis/compare_pitch_cli.py`
- `ruff check --fix src/spectrum_analysis/__init__.py src/spectrum_analysis/visualizer.py src/spectrum_analysis/compare_pitch_cli.py`
- `PYTHONPATH=src python - <<'PY'\nimport spectrum_analysis\nprint('exports', sorted(name for name in dir(spectrum_analysis) if not name.startswith('_')))\nfrom spectrum_analysis import compare_pitch_main\nprint(compare_pitch_main)\nPY` *(fails: ModuleNotFoundError: No module named 'matplotlib')*

------
https://chatgpt.com/codex/tasks/task_e_68dd8555cdc8832987144410a63c485e