### PR TITLE
Ensure CLI uses local spectrum_analysis package

### DIFF
--- a/src/spectrum_analysis/compare_pitch_cli.py
+++ b/src/spectrum_analysis/compare_pitch_cli.py
@@ -5,8 +5,16 @@ from __future__ import annotations
 import argparse
 import dataclasses
 import datetime as _dt
+import sys
 from pathlib import Path
 from typing import Any, Iterable, List, Optional, Tuple
+
+
+if __package__ in {None, ""}:
+    PROJECT_ROOT = Path(__file__).resolve().parents[2]
+    SRC_ROOT = PROJECT_ROOT / "src"
+    if SRC_ROOT.exists():
+        sys.path.insert(0, str(SRC_ROOT))
 
 import matplotlib.pyplot as plt
 from matplotlib.axes import Axes


### PR DESCRIPTION
## Summary
- ensure the pitch comparison CLI prepends the repository src directory to sys.path when executed directly so the local spectrum_analysis package is imported

## Testing
- python3 src/spectrum_analysis/compare_pitch_cli.py --help *(fails: ModuleNotFoundError: No module named 'matplotlib')*


------
https://chatgpt.com/codex/tasks/task_e_68def6941e488329bc580433e7d6d870