### PR TITLE
Add trigger mode selection to pitch comparison config

### DIFF
--- a/src/spectrum_analysis/audio_processing.py
+++ b/src/spectrum_analysis/audio_processing.py
@@ -422,7 +422,7 @@ def _acquire_audio_snr(cfg: "PitchCompareConfig", noise_rms: float) -> np.ndarra
 
 
 def acquire_audio(cfg: "PitchCompareConfig", noise_rms: float) -> np.ndarray:
-    """Record audio using harmonic-comb triggering or load from file."""
+    """Record audio using the configured trigger or load from file."""
 
     if cfg.input_mode == "file":
         if cfg.input_audio_path is None:
@@ -431,6 +431,11 @@ def acquire_audio(cfg: "PitchCompareConfig", noise_rms: float) -> np.ndarray:
             )
         audio, _ = load_audio(Path(cfg.input_audio_path), cfg.sample_rate)
         return audio
+
+    trigger_mode = getattr(cfg, "trigger_mode", "snr")
+
+    if trigger_mode != "harmonic_comb":
+        return _acquire_audio_snr(cfg, noise_rms)
 
     expected_f0 = cfg.expected_f0
     if expected_f0 is None or not np.isfinite(expected_f0) or expected_f0 <= 0.0:

--- a/src/spectrum_analysis/pitch_compare_config.json
+++ b/src/spectrum_analysis/pitch_compare_config.json
@@ -1,5 +1,6 @@
 {
   "snr_threshold_db": 1,
+  "trigger_mode": "snr",
   "max_record_seconds": 2,
   "input_mode": "mic",
   "input_audio_path": "/home/ben/DUNE-tension/data/test_fixture",


### PR DESCRIPTION
## Summary
- add a configurable `trigger_mode` to `PitchCompareConfig`, defaulting to the SNR trigger
- normalize trigger values from JSON and fall back to the default when invalid
- update audio acquisition to respect the configured trigger mode and keep SNR as the fallback

## Testing
- ruff check --fix src/spectrum_analysis/pitch_compare_config.py src/spectrum_analysis/audio_processing.py


------
https://chatgpt.com/codex/tasks/task_e_68dd940e1a348329a530d726dd2ac5a0